### PR TITLE
Expose API instance and transactionFinished event

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -1,7 +1,10 @@
 'use strict'
 
+var util = require('util')
+var EventEmitter = require('events').EventEmitter
 var _ = require('lodash')
 var Agent = require('newrelic/lib/agent')
+var API = require('newrelic/api')
 var configurator = require('newrelic/lib/config')
 var shimmer = require('newrelic/lib/shimmer')
 var testUtil = require('./util')
@@ -65,7 +68,14 @@ function TestAgent(conf, flags) {
   if (flags) {
     this.agent.config.feature_flag = _.assign({}, this.agent.config.feature_flag, flags)
   }
+
+  this.agent.on('transactionFinished', function(transaction) {
+    TestAgent.instance.emit('transactionEnd', transaction)
+  })
+
+  this.api = new API(this.agent)
 }
+util.inherits(TestAgent, EventEmitter)
 
 /**
  * The singleton instance of the `TestAgent` class.
@@ -172,4 +182,8 @@ TestAgent.prototype.runInTransaction = function runInTransaction(type, func) {
  */
 TestAgent.prototype.getTransaction = function getTransaction() {
   return this.agent.getTransaction()
+}
+
+TestAgent.prototype.getApi = function() {
+  return this.api
 }


### PR DESCRIPTION
The API instance is needed for registering instrumentation in tests.  The transactionFinished event is needed for checking metrics and segments when transaction is finalized.