### PR TITLE
Do not save installed packages.

### DIFF
--- a/lib/versioned/runner.js
+++ b/lib/versioned/runner.js
@@ -65,7 +65,7 @@ function installPackages(cb) {
   tryInstall(0)
 
   function tryInstall(attempts) {
-    var args = ['install']
+    var args = ['install', '--no-save']
     args = args.concat(packages)
     spawn('npm', args, function(err) {
       if (err) {


### PR DESCRIPTION
Latest versions of npm always save added modules to the `package.json` which is annoying when running several installs back-to-back.