### PR TITLE
NODE-1656 fix(runner): account for null exit code

### DIFF
--- a/lib/versioned/runner.js
+++ b/lib/versioned/runner.js
@@ -127,7 +127,7 @@ function spawn(cmd, args, cb) {
 
   child.on('exit', function(code) {
     clearTimeout(timeout)
-    if (code !== 0) {
+    if (code) {
       if (!error) {
         error = new Error('Failed to execute ' + cmd + ' ' + args.join(' '))
       }


### PR DESCRIPTION
Timed-out tests have been terminating with `null` codes, so they are always diverted through the wrong branch before ultimately finishing with a [false positive](https://github.com/newrelic/node-test-utilities/blob/master/lib/versioned/runner.js#L39) (`err.code` is falsey, therefore it exits with `0`).