### PR TITLE
Updated changelog for v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+### v1.0.0 (2018-02-20):
+
+- Added `TestAgent` helper class.
+
+  This class provides simple to use helpers for running your tests with the agent
+  and in transactions.
+
+- Added `tap` assertions.
+
+  If your tests use [`tap`](https://www.npmjs.com/package/tap), then you can add
+  some helpful assertions to your tests using this module.
+
+- Added version matrix test running.
+
+  This is a script for executing your instrumentation's tests against many
+  versions of the module you are instrumenting.

--- a/README.md
+++ b/README.md
@@ -82,3 +82,63 @@ tap.test((t) => {
   })
 })
 ```
+
+## Versioned Tests
+
+The `versioned-tests` script can be used to execute a series of tests against
+several versions of dependencies. For example, the command below would run all
+the tests against every minor version of the specified dependencies.
+
+```sh
+$ versioned-tests --minor tests/versioned/*.tap.js
+```
+
+You can then specify the versions you want to run this against by adding a
+`package.json` file in your tests directory. This package file should have a
+`tests` array describing each suite. For example, the one shown below will test
+different files for each version of `mongodb` from `v1.0.0` through to the latest.
+
+```json
+{
+  "name": "mongodb-tests",
+  "version": "0.0.0",
+  "private": true,
+  "tests": [
+    {
+      "engines": {
+        "node": ">=0.10 <7"
+      },
+      "dependencies": {
+        "mongodb": "^1"
+      },
+      "files": [
+        "v1-tests.tap.js"
+      ]
+    },
+    {
+      "engines": {
+        "node": ">=0.10"
+      },
+      "dependencies": {
+        "mongodb": ">=2.1 <3"
+      },
+      "files": [
+        "v2-tests.tap.js",
+        "shared-tests.tap.js"
+      ]
+    },
+    {
+      "engines": {
+        "node": ">=4"
+      },
+      "dependencies": {
+        "mongodb": ">=3"
+      },
+      "files": [
+        "v3-tests.tap.js",
+        "shared-tests.tap.js"
+      ]
+    }
+  ]
+}
+```


### PR DESCRIPTION
### v1.0.0 (2018-02-20):

- Added `TestAgent` helper class.

  This class provides simple to use helpers for running your tests with the agent
  and in transactions.

- Added `tap` assertions.

  If your tests use [`tap`](https://www.npmjs.com/package/tap), then you can add
  some helpful assertions to your tests using this module.

- Added version matrix test running.

  This is a script for executing your instrumentation's tests against many
  versions of the module you are instrumenting.
