### PR TITLE
NODE-1703 Added hook for specifying newrelic path.

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -1,10 +1,13 @@
 'use strict'
 
 var _ = require('lodash')
-var Agent = require('newrelic/lib/agent')
-var configurator = require('newrelic/lib/config')
-var shimmer = require('newrelic/lib/shimmer')
 var testUtil = require('./util')
+
+var newRelicLoc = testUtil.getNewRelicLocation()
+var Agent = require(newRelicLoc + '/lib/agent')
+var configurator = require(newRelicLoc + '/lib/config')
+var shimmer = require(newRelicLoc + '/lib/shimmer')
+
 
 module.exports = TestAgent
 

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -2,8 +2,10 @@
 
 var _ = require('lodash')
 var TestAgent = require('./agent')
-var Transaction = require('newrelic/lib/transaction')
+var testUtil = require('./util')
 var util = require('util')
+
+var Transaction = require(testUtil.getNewRelicLocation() + '/lib/transaction')
 
 
 /**

--- a/lib/util.js
+++ b/lib/util.js
@@ -65,3 +65,13 @@ util.niceDuration = function niceDuration(duration) {
   }
   return Math.round(duration) + 'ms'
 }
+
+/**
+ * Returns the location of the New Relic agent package as would be used by
+ * `require` to load the module.
+ *
+ * @return {string} The location of the agent package.
+ */
+util.getNewRelicLocation = function getNewRelicLocation() {
+  return process.env.AGENT_PATH || 'newrelic'
+}

--- a/tests/unit/agent.tap.js
+++ b/tests/unit/agent.tap.js
@@ -1,12 +1,14 @@
 'use strict'
-var s = Date.now()
 
-var TestAgent = require('../../lib/agent')
-var shimmer = require('newrelic/lib/shimmer')
-var tap = require('tap')
 var sinon = require('sinon')
+var tap = require('tap')
+var TestAgent = require('../../lib/agent')
+var testUtil = require('../../lib/util')
+
+var shimmer = require(testUtil.getNewRelicLocation() + '/lib/shimmer')
 
 require('../../lib/assert').extendTap(tap)
+
 
 tap.afterEach(function(done) {
   if (TestAgent.instance) {
@@ -21,7 +23,7 @@ tap.test('new TestAgent', function(t) {
   // Check singleton-ness
   t.equal(helper, TestAgent.instance, 'should make instance available on class')
   t.throws(function() {
-    var second = new TestAgent()
+    return new TestAgent()
   }, Error, 'should enforce singleton nature of Agent')
 
   t.end()

--- a/tests/unit/util.tap.js
+++ b/tests/unit/util.tap.js
@@ -38,3 +38,20 @@ tap.test('testUtil.removeListenerByName', function(t) {
 
   t.end()
 })
+
+tap.test('testUtil.getNewRelicLocation', function(t) {
+  var startingPath = process.env.AGENT_PATH
+  t.tearDown(function() {
+    process.env.AGENT_PATH = startingPath
+  })
+
+  var getNewRelicLocation = testUtil.getNewRelicLocation
+
+  delete process.env.AGENT_PATH
+  t.equal(getNewRelicLocation(), 'newrelic', 'should default to installed module')
+
+  process.env.AGENT_PATH = 'foo/bar'
+  t.equal(getNewRelicLocation(), 'foo/bar', 'should use environtment value when set')
+
+  t.end()
+})


### PR DESCRIPTION
Added check for `AGENT_PATH` environment variable.

This environment variable can be used to specify the location of the `newrelic` package that these test utilities will load. It should be the path to the root directory of the agent. If the environment variable is not set, then the `newrelic` module that was installed (e.g. is in a `node_modules` directory) is used instead.