### PR TITLE
Fixed test naming

### DIFF
--- a/bin/version-manager.js
+++ b/bin/version-manager.js
@@ -43,6 +43,7 @@ a.waterfall([
       var cwd = process.cwd()
       globs.push(path.join(cwd, 'test/versioned/**/package.json'))
       globs.push(path.join(cwd, 'tests/versioned/**/package.json'))
+      globs.push(path.join(cwd, 'node_modules/**/tests/versioned/package.json'))
       globs.push(path.join(cwd, 'node_modules/**/tests/versioned/**/package.json'))
     }
 
@@ -67,10 +68,7 @@ function printMode(mode) {
 
 function resolveGlobs(globs, cb) {
   a.map(globs, function(g, cb) {
-    glob(g, {
-      ignore: '**/node_modules/**',
-      absolute: true
-    }, cb)
+    glob(g, {absolute: true}, cb)
   }, function afterGlobbing(err, resolved) {
     if (err) {
       console.error('Error globbing:', err)
@@ -78,12 +76,13 @@ function resolveGlobs(globs, cb) {
     }
     var files = resolved.reduce(function mergeResolved(tests, b) {
       b.forEach(function(file) {
-        if (tests.indexOf(file) === -1) {
+        var inNodeModules = (/\/node_modules\/(?!@newrelic\/)/g).test(file)
+        if (!inNodeModules && tests.indexOf(file) === -1) {
           tests.push(file)
         }
       })
       return tests
-    })
+    }, [])
     if (!files || !files.length) {
       console.error('No files matched', globs)
       process.exit(0)

--- a/lib/versioned/printers/printer.js
+++ b/lib/versioned/printers/printer.js
@@ -9,13 +9,18 @@ var HR = '==============================================================='
 
 
 function TestPrinter(tests, opts) {
-  this.tests = tests.map(function(t) {
-    var testDirectory = path.basename(path.dirname(t))
-    return {name: testDirectory, status: 'created', test: null}
+  this.tests = tests.map(function(tPath) {
+    var tDir = path.dirname(tPath)
+    var tName = path.basename(tDir)
+    if (tName === 'versioned') {
+      tName = require(path.join(tDir, 'package')).name
+    }
+    return {name: tName, status: 'created', test: null}
   }).reduce(function(testMap, t) {
     testMap[t.name] = t
     return testMap
   }, {})
+
   this.opts = opts
   this.updated = false
 
@@ -36,16 +41,16 @@ TestPrinter.prototype.end = function() {
 }
 
 TestPrinter.prototype._doUpdate = function(test, status, shouldPrint) {
-  var testDir = path.basename(test.directory)
-  this.tests[testDir].test = test
-  this.tests[testDir].status = status
+  var testName = test.name
+  this.tests[testName].test = test
+  this.tests[testName].status = status
   this.updated = this.updated || shouldPrint
 
   if (status === 'error' || status === 'failure') {
     this._printError(test)
   }
 
-  return testDir
+  return testName
 }
 
 TestPrinter.prototype._printError = function(test) {

--- a/lib/versioned/printers/simple.js
+++ b/lib/versioned/printers/simple.js
@@ -34,8 +34,8 @@ SimplePrinter.prototype.print = function() {
   }
   var updatedTests = this._updatedTests
   this._updatedTests = []
-  updatedTests.forEach(function(testDir) {
-    console.log(this._formatTest(testDir)) // eslint-disable-line no-console
+  updatedTests.forEach(function(testName) {
+    console.log(this._formatTest(testName)) // eslint-disable-line no-console
   }, this)
 }
 

--- a/lib/versioned/test.js
+++ b/lib/versioned/test.js
@@ -11,11 +11,12 @@ var TestMatrix = require('./matrix')
 var TEST_EXECUTOR = path.resolve(__dirname, './runner.js')
 
 function Test(directory, pkgVersions) {
+  var pkg = require(path.join(directory, 'package'))
+  var dirname = path.basename(directory)
+
+  this.name = dirname === 'versioned' ? pkg.name : dirname
   this.directory = directory
-  this.matrix = new TestMatrix(
-    require(path.join(directory, 'package')).tests,
-    pkgVersions
-  )
+  this.matrix = new TestMatrix(pkg.tests, pkgVersions)
   this.runs = 0
   this.failed = false
   this.currentRun = null


### PR DESCRIPTION
Versioned tests are now named better when they are coming from the `versioned` directory directly. In that case, the name from the package.json is used instead.