### PR TITLE
Added default messages to asserts

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -193,5 +193,10 @@ TestAgent.prototype.getTransaction = function getTransaction() {
  *  Module instrumentation.
  */
 TestAgent.prototype.registerInstrumentation = function registerInstrumentation(opts) {
+  if (!opts.onError) {
+    opts.onError = function throwOnError(err) {
+      throw err
+    }
+  }
   shimmer.registerInstrumentation(opts)
 }

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -165,18 +165,22 @@ assert.exactSegments = _asserter2(_exactSegmentsTest)
 
 function _transactionTest(tx) {
   var currentTx = TestAgent.instance && TestAgent.instance.getTransaction()
-  if (tx === null || tx === undefined) {
-    return 'Transaction is null.'
+  var txName = tx ? tx.id : '<null>'
+  var currentName = currentTx ? currentTx.id : '<null>'
+  if (tx == null) {
+    return {message: 'Transaction is ' + txName}
   } else if (!(tx instanceof Transaction)) {
-    return 'Transaction is not an instance of Transaction class.'
+    return {message: 'Transaction is not an instance of Transaction class.'}
   } else if (!currentTx || tx.id !== currentTx.id) {
-    return util.format(
-      'Transaction (%s) is not the current transaction (%s)',
-      tx.id, currentTx ? currentTx.id : '<null>'
-    )
+    return {
+      message: util.format(
+        'Transaction (%s) is not the current transaction (%s)',
+        txName, currentName
+      )
+    }
   }
 
-  return null
+  return {success: true, message: 'Transaction is ' + txName}
 }
 
 function _metricsTest(expected, exact) {
@@ -199,27 +203,34 @@ function _metricsTest(expected, exact) {
 
     var metric = metrics.getMetric(name, scope)
     if (!metric) {
-      return util.format(
-        'Missing metric named "%s" in scope %s',
-        name, scope || '<null>'
-      )
+      return {
+        message: util.format(
+          'Missing metric named "%s" in scope %s',
+          name, scope || '<null>'
+        )
+      }
     }
 
     // Note that if expectedMetric is empty (i.e. only name and scope given)
     // then this `isMatch` will be true, effectively disabling this check.
     if (!_.isMatch(metric, expectedMetric)) {
-      return util.format('Metric %s does not match expected.', name)
+      return {message: util.format('Metric %s does not match expected.', name)}
     }
   }
 
   if (exact && metrics.toJSON().length !== expected.length) {
-    return util.format(
-      'Metric has %d elements, expected %d.',
-      metrics.toJSON().length, expected.length
-    )
+    return {
+      message: util.format(
+        'Metric has %d elements, expected %d.',
+        metrics.toJSON().length, expected.length
+      )
+    }
   }
 
-  return null
+  return {
+    success: true,
+    message: 'Metrics are ' + (exact ? 'exactly' : 'loosely') + ' as expected.'
+  }
 }
 
 function _exactMetricsTest(expected) {
@@ -251,14 +262,14 @@ function _segmentsTest(parent, _expected) {
       var child = findChild(children, expectedChild.name)
 
       if (!child) {
-        return util.format('Missing child segment "%s"', expectedChild.name)
+        return {message: util.format('Missing child segment "%s"', expectedChild.name)}
       }
 
       if (expectedChild.children) {
         if (expectedChild.exact) {
-          var err = _exactSegmentsTest(child, expectedChild.children)
-          if (err) {
-            return err
+          var res = _exactSegmentsTest(child, expectedChild.children)
+          if (!res.success) {
+            return res
           }
         } else {
           stack.push([child.children, expectedChild.children])
@@ -267,7 +278,7 @@ function _segmentsTest(parent, _expected) {
     }
   }
 
-  return null
+  return {success: true, message: 'Segments are as expected.'}
 }
 
 function _exactSegmentsTest(parent, _expected) {
@@ -282,23 +293,27 @@ function _exactSegmentsTest(parent, _expected) {
       var expectedChild = expected[i]
       var child = children[i]
       if (!child) {
-        return util.format(
-          'Expected segment "%s" as child %d of "%s", found no child.',
-          expectedChild.name, i, parent.name
-        )
+        return {
+          message: util.format(
+            'Expected segment "%s" as child %d of "%s", found no child.',
+            expectedChild.name, i, parent.name
+          )
+        }
       }
       if (child.name !== expectedChild.name) {
-        return util.format(
-          'Expected segment "%s" as child %d of "%s", found "%s" instead.',
-          expectedChild.name, i, parent.name, child.name
-        )
+        return {
+          message: util.format(
+            'Expected segment "%s" as child %d of "%s", found "%s" instead.',
+            expectedChild.name, i, parent.name, child.name
+          )
+        }
       }
 
       if (expectedChild.children) {
         if (expectedChild.exact === false) {
-          var err = _segmentsTest(child, expectedChild.children)
-          if (err) {
-            return err
+          var res = _segmentsTest(child, expectedChild.children)
+          if (!res.success) {
+            return res
           }
         } else {
           stack.push([child.children, expectedChild.children])
@@ -307,51 +322,53 @@ function _exactSegmentsTest(parent, _expected) {
     }
 
     if (children.length !== expected.length) {
-      return util.format(
-        'Expected %d children for segment "%s", found %d instead.',
-        expected.length, parent.name, children.length
-      )
+      return {
+        message: util.format(
+          'Expected %d children for segment "%s", found %d instead.',
+          expected.length, parent.name, children.length
+        )
+      }
     }
   }
 
-  return null
+  return {success: true, message: 'Segments are exactly as expected.'}
 }
 
 
 function _asserter1(test) {
   return function asertionTest(x, message) {
-    var err = test(x)
-    if (err) {
-      throw new Error(message || err)
+    var res = test(x)
+    if (!res.success) {
+      throw new Error(message || res.message)
     }
   }
 }
 
 function _asserter2(test) {
   return function asertionTest(x, y, message) {
-    var err = test(x, y)
-    if (err) {
-      throw new Error(message || err)
+    var res = test(x, y)
+    if (!res.success) {
+      throw new Error(message || res.message)
     }
   }
 }
 
 function _tapper1(test) {
   return function tapTest(x, message, extra) {
-    var err = test(x)
-    if (err) {
-      return this.fail(message || err, extra)
+    var res = test(x)
+    if (!res.success) {
+      return this.fail(message || res.message, extra)
     }
-    return this.pass(message, extra)
+    return this.pass(message || res.message, extra)
   }
 }
 
 function _tapper2(test) {
   return function tapTest(x, y, message, extra) {
-    var err = test(x, y)
-    if (err) {
-      return this.fail(message || err, extra)
+    var res = test(x, y)
+    if (!res.success) {
+      return this.fail(message || res.message, extra)
     }
-    return this.pass(message, extra)
+    return this.pass(message || res.message, extra)
   }
 }

--- a/tests/unit/assert.tap.js
+++ b/tests/unit/assert.tap.js
@@ -37,7 +37,7 @@ tap.test('assert.extendTap', function(t) {
 tap.test('assert.transaction', function(t) {
   t.throws(function() {
     assert.transaction(null)
-  }, {message: /is null/}, 'should throw if no transaction given')
+  }, {message: /is <null>/}, 'should throw if no transaction given')
   t.throws(function() {
     assert.transaction({})
   }, {message: /is not a.*?Transaction/}, 'should throw if not a Transaction')


### PR DESCRIPTION
This change allows people to use `t.transaction(tx)` and still have a meaningful message.