### PR TITLE
Added `isLocalhost` and `getDelocalizedHostname`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,10 +1,11 @@
 {
   "env": {
+    "es6": true,
     "node": true,
     "browser": false
   },
-  "globals": {
-    "Promise": true
+  "parserOptions": {
+    "ecmaVersion": 6
   },
   "rules": {
     "brace-style": "error",

--- a/index.js
+++ b/index.js
@@ -13,6 +13,9 @@ var testUtil = require('./lib/util')
  * @module test-utilities
  */
 
+// Export utility methods directly.
+Object.assign(exports, testUtil)
+
 exports = module.exports = function extendTap(tap) {
   assert.extendTap(tap)
 

--- a/index.js
+++ b/index.js
@@ -13,14 +13,14 @@ var testUtil = require('./lib/util')
  * @module test-utilities
  */
 
-// Export utility methods directly.
-Object.assign(exports, testUtil)
-
 exports = module.exports = function extendTap(tap) {
   assert.extendTap(tap)
 
   return exports
 }
+
+// Export utility methods directly.
+Object.assign(exports, testUtil)
 
 /** @type TestAgent */
 exports.TestAgent = TestAgent

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -1,12 +1,12 @@
 'use strict'
 
-var _ = require('lodash')
-var testUtil = require('./util')
+const _ = require('lodash')
+const testUtil = require('./util')
 
-var newRelicLoc = testUtil.getNewRelicLocation()
-var Agent = require(newRelicLoc + '/lib/agent')
-var configurator = require(newRelicLoc + '/lib/config')
-var shimmer = require(newRelicLoc + '/lib/shimmer')
+const newRelicLoc = testUtil.getNewRelicLocation()
+const Agent = require(newRelicLoc + '/lib/agent')
+const configurator = require(newRelicLoc + '/lib/config')
+const shimmer = require(newRelicLoc + '/lib/shimmer')
 
 
 module.exports = TestAgent

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,11 +1,14 @@
 'use strict'
 
+const urltils = require(getNewRelicLocation() + '/lib/util/urltils')
+
+
 /**
  * New Relic test utility functions.
  *
  * @namespace util
  */
-var util = module.exports
+const util = module.exports
 
 /**
  * Tests if the given item is a function.
@@ -72,6 +75,42 @@ util.niceDuration = function niceDuration(duration) {
  *
  * @return {string} The location of the agent package.
  */
-util.getNewRelicLocation = function getNewRelicLocation() {
+util.getNewRelicLocation = getNewRelicLocation
+function getNewRelicLocation() {
   return process.env.AGENT_PATH || 'newrelic'
+}
+
+/**
+ * Checks if the given hostname or IP address is a common name for localhost.
+ *
+ * @type function
+ *
+ * This does not perform any lookup, it simply checks the given string against a
+ * known list of common names or localhost.
+ *
+ * @param {string} hostname - The host name or IP address to check.
+ *
+ * @return {bool} True if the given hostname is localhost.
+ */
+util.isLocalhost = urltils.isLocalhost
+
+/**
+ * Returns the given hostname if it is not localhost, or looks up the name of
+ * this host if it is localhost.
+ *
+ * @param {string} hostname - The hostname to delocalize.
+ *
+ * @return {string} The name of the host identified.
+ */
+util.getDelocalizedHostname = function getDelocalizedHostname(hostname) {
+  // Getting the host name requires an instance of the config object, which
+  // requires an agent. This results in a circular reference between this module
+  // and TestAgent.
+  //
+  // TODO: Move `config.getHostnameSafe` to a static utility method and have the
+  // config cache the result of that function.
+  const TestAgent = require('./agent')
+  return util.isLocalhost(hostname)
+    ? TestAgent.instance.agent.config.getHostnameSafe()
+    : hostname
 }

--- a/lib/versioned/suite.js
+++ b/lib/versioned/suite.js
@@ -23,7 +23,7 @@ function Suite(testFolders, opts) {
 util.inherits(Suite, EventEmitter)
 
 Suite.prototype.start = function(cb) {
-  // Figure out the union of all packages required by all of the tests looks like.
+  // Figure out the union of all packages required by all of the tests.
   //
   // TODO: When Node v0.8 and v0.10 are no longer supported change this to use `Set`.
   var packages = Object.keys(this.testFolders.map(function(folder) {
@@ -135,7 +135,7 @@ Suite.prototype._runTests = function(pkgVersions, cb) {
   }, this.opts.limit)
 
   // Build and queue all of our test directories. The tests are sorted by number
-  // of runs required so the longer tests start sooner
+  // of runs required so the longer tests start sooner.
   this.tests = this.testFolders.map(function(t) {
     return new Test(t, pkgVersions)
   }).sort(function(a, b) {

--- a/tests/unit/util.tap.js
+++ b/tests/unit/util.tap.js
@@ -1,10 +1,11 @@
 'use strict'
 
-var EventEmitter = require('events').EventEmitter
-var tap = require('tap')
-var testUtil = require('../../lib/util')
+const EventEmitter = require('events').EventEmitter
+const tap = require('tap')
+const TestAgent = require('../../lib/agent')
+const testUtil = require('../../lib/util')
 
-tap.test('testUtil.isFunction', function(t) {
+tap.test('testUtil.isFunction', (t) => {
   t.ok(testUtil.isFunction(function() {}), 'should return true for functions')
   t.notOk(testUtil.isFunction(true), 'should return false for not-functions')
   t.notOk(testUtil.isFunction(1234), 'should return false for not-functions')
@@ -15,7 +16,7 @@ tap.test('testUtil.isFunction', function(t) {
   t.end()
 })
 
-tap.test('testUtil.removeListenerByName', function(t) {
+tap.test('testUtil.removeListenerByName', (t) => {
   t.plan(2)
   var emitter = new EventEmitter()
 
@@ -39,10 +40,10 @@ tap.test('testUtil.removeListenerByName', function(t) {
   t.end()
 })
 
-tap.test('testUtil.getNewRelicLocation', function(t) {
+tap.test('testUtil.getNewRelicLocation', (t) => {
   var startingPath = process.env.AGENT_PATH
   t.tearDown(function() {
-    process.env.AGENT_PATH = startingPath
+    process.env.AGENT_PATH = (startingPath || '')
   })
 
   var getNewRelicLocation = testUtil.getNewRelicLocation
@@ -53,5 +54,30 @@ tap.test('testUtil.getNewRelicLocation', function(t) {
   process.env.AGENT_PATH = 'foo/bar'
   t.equal(getNewRelicLocation(), 'foo/bar', 'should use environtment value when set')
 
+  t.end()
+})
+
+tap.test('testUtil.isLocalhost', (t) => {
+  t.ok(testUtil.isLocalhost('localhost'), 'should be true for localhost')
+  t.ok(testUtil.isLocalhost('127.0.0.1'), 'should be true for home IP')
+  t.notOk(testUtil.isLocalhost('example.com'), 'should be false for domain name')
+  t.end()
+})
+
+tap.test('testUtil.getDelocalizedHostname', (t) => {
+  // Need an agent instance for `getDelocalizedHostname`.
+  const agent = new TestAgent()
+  t.tearDown(() => agent.unload())
+
+  t.equal(
+    testUtil.getDelocalizedHostname('foobar'),
+    'foobar',
+    'should not change non-local names'
+  )
+  t.notEqual(
+    testUtil.getDelocalizedHostname('localhost'),
+    'localhost',
+    'should change localhost'
+  )
   t.end()
 })


### PR DESCRIPTION
* Added `isLocalhost` and `getDelocalizedHostname` to utilities methods.

  These methods are useful for determining the host name as the New Relic agent sees it. When making metrics and event attributes, the delocalized hostname is what the agent will use.