### PR TITLE
Dropping support for 0.10 and 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,28 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
   - "4"
   - "5"
   - "6"
   - "7"
   - "8"
   - "9"
+  - "10"
 env:
   - SUITE=unit
   - SUITE=lint
 matrix:
   exclude:
-    - node_js: "0.10"
-      env: SUITE=lint
-    - node_js: "0.12"
-      env: SUITE=lint
     - node_js: "4"
       env: SUITE=lint
     - node_js: "5"
+      env: SUITE=lint
+    - node_js: "6"
+      env: SUITE=lint
+    - node_js: "7"
+      env: SUITE=lint
+    - node_js: "8"
+      env: SUITE=lint
+    - node_js: "9"
       env: SUITE=lint
 install:
   - npm install

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     }
   ],
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=4.0"
   },
   "devDependencies": {
     "eslint": "^4.18.0",

--- a/tests/unit/versioned/test.tap.js
+++ b/tests/unit/versioned/test.tap.js
@@ -127,14 +127,13 @@ tap.test('Test methods and members', function(t) {
 
       t.notOk(testRun.failed, 'should not be marked as failed')
 
-      /* eslint-disable max-len */
       t.match(testRun.stdout, new RegExp([
-        '(?:\\+\\s|mock-tests@1\\.0\\.0 /.+?/tests/unit/versioned/mock-tests',
-        '└── )?redis@1\\.0\\.0.*?\n?(?:\nupdated \\d+ packages? in \\d(?:\\.\\d+)?s)?',
-        'stdout - redis\\.mock\\.js',
-        ''
-      ].join('\n')), 'should have expected stdout')
-      /* eslint-enable max-len */
+        '(?:\\+\\s|mock-tests@1\\.0\\.0 /.+?/tests/unit/versioned/mock-tests\n',
+        '└── )?redis@1\\.0\\.0.*?\n?',
+        '(?:\nupdated \\d+ packages? in \\d(?:\\.\\d+)?s)?\n?',
+        '(?:\nfound \\d+ vulnerabilities)?\n?',
+        '\nstdout - redis\\.mock\\.js\n'
+      ].join('')), 'should have expected stdout')
 
       t.equal(testRun.stderr, 'stderr - redis.mock.js\n', 'should have expected stderr')
 


### PR DESCRIPTION
These versions of Node are no longer supported by the agent, so they are being dropped by the test library.