### PR TITLE
add setState arg to TestAgent constructor

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const _ = require('lodash')
 const testUtil = require('./util')
 
 const newRelicLoc = testUtil.getNewRelicLocation()
@@ -12,10 +11,9 @@ const shimmer = require(newRelicLoc + '/lib/shimmer')
 module.exports = TestAgent
 
 /**
- * Constructs a new TestAgent with a given configuration and enables feature
- * flags if specified.
+ * Constructs a new TestAgent with a given configuration.
  *
- * - `new TestAgent([conf [,flags]])`
+ * - `new TestAgent([conf [,setState]])`
  *
  * @constructor
  * @classdesc
@@ -42,10 +40,10 @@ module.exports = TestAgent
  *    done()
  *  })
  *
- * @param {?object} [conf]  - A newrelic agent configuration.
- * @param {?object} [flags] - Feature flags to enable after configuring.
+ * @param {?object}  [conf]          - A newrelic agent configuration.
+ * @param {?boolean} [setState=true] - Initialize agent with 'started' state.
  */
-function TestAgent(conf, flags) {
+function TestAgent(conf, setState) {
   // Maintain the one-agent-only requirement.
   if (TestAgent.instance) {
     throw TestAgent.instance._created
@@ -62,11 +60,15 @@ function TestAgent(conf, flags) {
 
   // Create our new agent.
   this.agent = new Agent(config)
-  this._created = new Error("Only one agent at a time! This one was created at:")
+  this._created = new Error('Only one agent at a time! This one was created at:')
 
-  // Enable any feature flags listed.
-  if (flags) {
-    this.agent.config.feature_flag = _.assign({}, this.agent.config.feature_flag, flags)
+  if (setState == null) {
+    setState = true
+  }
+
+  // Allow automatic data collection
+  if (setState) {
+    this.agent.setState('started')
   }
 }
 
@@ -83,15 +85,15 @@ TestAgent.instance = null
  * Factory method for constructing an agent helper and bootstrapping agent
  * instrumentation.
  *
- * - `TestAgent.makeInstrumented([conf [, flags]])`
+ * - `TestAgent.makeInstrumented([conf [, setState]])`
  *
- * @param {?object} [conf]  - A newrelic agent configuration.
- * @param {?object} [flags] - Feature flags to enable after configuring.
+ * @param {?object}  [conf]          - A newrelic agent configuration.
+ * @param {?boolean} [setState=true] - Initialize agent with 'started' state.
  *
  * @return {TestAgent} The newly created `TestAgent` instance.
  */
-TestAgent.makeInstrumented = function makeInstrumented(conf, flags) {
-  var helper = new TestAgent(conf, flags)
+TestAgent.makeInstrumented = function makeInstrumented(conf, setState) {
+  var helper = new TestAgent(conf, setState)
   helper.instrument()
   return helper
 }


### PR DESCRIPTION
* Added `setState` argument to `TestAgent` constructor, which allows for automatic data collection in tests by default.

* Removed obsoleted `flags` argument from `TestAgent` constructor. Feature flags are now accounted for in standard config.