### PR TITLE
NODE-2155 Error on signal Interrupts with No Error Code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,9 @@
 language: node_js
 node_js:
-  - "4"
-  - "5"
-  - "6"
-  - "7"
   - "8"
   - "9"
   - "10"
+  - "12"
 env:
   - SUITE=unit
   - SUITE=lint

--- a/lib/versioned/runner.js
+++ b/lib/versioned/runner.js
@@ -125,8 +125,9 @@ function spawn(cmd, args, cb) {
     error = err
   })
 
-  child.on('exit', function(code) {
+  child.on('exit', function(code, signal) {
     clearTimeout(timeout)
+
     if (code) {
       if (!error) {
         error = new Error('Failed to execute ' + cmd + ' ' + args.join(' '))
@@ -136,6 +137,19 @@ function spawn(cmd, args, cb) {
       error = new Error('Command timed out: ' + cmd + ' ' + args.join(' '))
       error.code = 0xbad
     }
+
+    // https://nodejs.org/api/child_process.html#child_process_event_exit
+    // If the process exited, code is the final exit code of the process,
+    // otherwise null. If the process terminated due to receipt of a signal,
+    // signal is the string name of the signal, otherwise null. One of the
+    // two will always be non-null.
+    if (null === code && !error && signal) {
+      // if there's no exit code but we exited due to a received signal,
+      // raise an appropriate error.
+      error = new Error('Aborted with signal ' + signal + ' ' + cmd + ' ' + args.join(' '))
+      error.code = 0xbad
+    }
+
     cb(error)
   })
 

--- a/lib/versioned/runner.js
+++ b/lib/versioned/runner.js
@@ -146,7 +146,9 @@ function spawn(cmd, args, cb) {
     if (null === code && !error && signal) {
       // if there's no exit code but we exited due to a received signal,
       // raise an appropriate error.
-      error = new Error('Aborted with signal ' + signal + ' ' + cmd + ' ' + args.join(' '))
+      error = new Error(
+        'Aborted with signal ' + signal + ' ' + cmd + ' ' + args.join(' ')
+      )
       error.code = 0xbad
     }
 


### PR DESCRIPTION
So, fun facts -- our versioned test runner does a lot of managing its own child proesses via the NodeJS core [child_process](https://nodejs.org/api/child_process.html) module.  

> The child_process module provides the ability to spawn child processes in a manner that is similar, but not identical, to popen(3).

Is there any phrase more terrifying than "similar, but not identical?" 

It appears that child processes created via the `spawn` method can exit with `null` (not 0) exit codes, and will do so when terminations happens due to signals like `SIGSEGV` (instead of passing on the actual posix error code).  This tricked our versioned test runner into thinking these tests did not fail.  The PR fixes that.

Before we merge we'll need to do something about our BlueBird tests on Node 10.  Right now both the `methods.tap.js` and `transaction-state.tap.js` tests are failing with segmentation faults or bus errors. 