### PR TITLE
updated engines field to at least v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     }
   ],
   "engines": {
-    "node": ">=4.0"
+    "node": ">=8.0"
   },
   "devDependencies": {
     "eslint": "^4.18.0",


### PR DESCRIPTION
* **BREAKING** Removed support for Node 6, 7, and 9.

  The minimum supported version is now Node v8. For further information on our support policy, see: https://docs.newrelic.com/docs/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.