### PR TITLE
added a samples flag to deps to allow for version limiting

### DIFF
--- a/lib/versioned/matrix.js
+++ b/lib/versioned/matrix.js
@@ -50,7 +50,16 @@ function TestMatrix(tests, pkgVersions) {
   // an array of test files. These look like this:
   //  [{
   //    "engines": {"node": ">=4"}
-  //    "dependencies": {"redis": ">=1.0.0"},
+  //    "dependencies": {"redis": "1.0.0"},
+  //    "files": ["redis.tap.js"]
+  //  }, {
+  //    "engines": {"node": ">=4"}
+  //    "dependencies": {
+  //      "redis": {
+  //        "versions": ">1.0.0",
+  //        "samples": 10
+  //      }
+  //    },
   //    "files": ["redis.tap.js"]
   //  }]
   //
@@ -91,6 +100,13 @@ function TestMatrix(tests, pkgVersions) {
     }
     task.packages = Object.keys(test.dependencies).map(function(pkg) {
       var wantedVersions = test.dependencies[pkg]
+      var samples = null
+
+      if (typeof wantedVersions === 'object') {
+        samples = wantedVersions.samples
+        wantedVersions = wantedVersions.versions
+      }
+
       var pkgIterator = {
         name: pkg,
         next: 0,
@@ -115,6 +131,24 @@ function TestMatrix(tests, pkgVersions) {
           pkgIterator.versions = [matching[matching.length - 1]]
         }
       }
+
+      // Sample the versions down to the limit if applicable
+      var versions = pkgIterator.versions
+      if (samples != null && versions.length > samples) {
+        // Since we take the latest version, we drop an intermediate version
+        samples -= 1
+
+        var sampledVersions = []
+        for (var i = 0; i < samples; i += 1) {
+          sampledVersions[i] = versions[Math.floor(versions.length * i / samples)]
+        }
+
+        // Always take the latest
+        sampledVersions.push(versions[versions.length - 1])
+
+        pkgIterator.versions = sampledVersions
+      }
+
       return pkgIterator
     })
     return task


### PR DESCRIPTION
allows for limiting the number of versions being run against per dependency in the dependencies object.

an example configuration would be as such:
```
{
  "name": "aws-sdk-tests",
  "version": "0.0.0",
  "private": true,
  "tests": [
    {
      "engines": {
        "node": ">=8.0"
      },
      "dependencies": {
        "aws-sdk": {
          "versions": ">=2.380.0",
          "samples": 10
        }
      },
      "files": [
        "aws-sdk.tap.js",
        "dynamodb.tap.js",
        "http-services.tap.js",
        "s3.tap.js"
      ]
    }
  ],
  "dependencies": {}
}
```