### PR TITLE
Adds handling of duplicate sibling names when searching for children.

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -248,14 +248,22 @@ function _segmentsTest(parent, _expected) {
   //  [{name: "name", children: [{name: "child"}]}]
   var stack = [[parent.children, _expected]]
 
-  var findChild = function findChild(children, name) {
-    // FIXME: Change to `.find` after deprecating 0.10 and 0.12.
-    return children.filter(function findChild_childrenFind(child) {
+  function findFirstChild(children, name) {
+    return children.find(function findChild_childrenFind(child) {
       if (name instanceof RegExp) {
         return name.test(child.name)
       }
       return child.name.indexOf(name) >= 0
-    })[0] // <-- FIXME remove this too.
+    })
+  }
+
+  function findMatchingChildren(children, name) {
+    return children.filter(function childrenFilter(child) {
+      if (name instanceof RegExp) {
+        return name.test(child.name)
+      }
+      return child.name.indexOf(name) >= 0
+    })
   }
 
   while (stack.length) {
@@ -265,7 +273,20 @@ function _segmentsTest(parent, _expected) {
 
     for (var i = 0; i < expected.length; ++i) {
       var expectedChild = expected[i]
-      var child = findChild(children, expectedChild.name)
+
+      const matches = findMatchingChildren(children, expectedChild.name)
+
+      let child = matches[0]
+      if (matches.length > 1 && expectedChild.children) {
+        // pre-test first grand-child to find appropriate match
+        const firstMatchingChild = matches.find((matchChild) => {
+          const firstGrandchildTest = expectedChild.children[0]
+          const grandchild = findFirstChild(matchChild.children, firstGrandchildTest.name)
+          return grandchild
+        })
+
+        child = firstMatchingChild || child
+      }
 
       if (!child) {
         return {message: util.format('Missing child segment "%s"', expectedChild.name)}

--- a/tests/unit/assert.tap.js
+++ b/tests/unit/assert.tap.js
@@ -152,6 +152,20 @@ tap.test('assert.segments', function(t) {
     assert.segments(root, [{name: 'child', children: [{name: 'grandchild'}]}])
   }, 'should work with nested segments')
 
+  const grandChild2 = child.add('grandchild')
+  grandChild2.add('great grandchild')
+  t.doesNotThrow(() => {
+    assert.segments(root, [{
+      name: 'child',
+      children: [{
+        name: 'grandchild',
+        children: [{
+          name: 'great grandchild'
+        }]
+      }]
+    }])
+  }, 'should honor position for identical siblings')
+
   t.throws(function() {
     assert.segments(root, [{name: 'doesNotExist'}])
   }, {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Added better handling of soft-matching segments for cases where siblings have duplicate names.

## Links

## Details

This is sort of a quick/naive fix that will search one more level when multiple siblings are found with the same matching name. A common example would be `middleware: <anonymous>`.  This solution will grab the first child that has a grandchild that also matches the next level.

A better long-term fix would add depth search but it would require a larger overhaul of the logic and may not get to the level of need. The expectedSegments tends to be used more but for my use case, I didn't want to account for every possible segment by frameworks in play.
