### PR TITLE
includes _every_ version the tests are being run on for transparency

### DIFF
--- a/bin/version-manager.js
+++ b/bin/version-manager.js
@@ -74,7 +74,7 @@ function buildGlobs(cb) {
     globs.push(path.join(cwd, 'node_modules/**/tests/versioned/**/package.json'))
   }
 
-  console.log('Finding tests in %d globs', globs.length)
+  console.log('Finding tests in %d globs'.yellow, globs.length)
   cb(null, globs)
 }
 
@@ -139,8 +139,9 @@ function run(files) {
   runner.on('update', viewer.update.bind(viewer))
   runner.on('end', viewer.end.bind(viewer))
 
+  console.log('Finding all versions for a package'.yellow)
   runner.on('packageResolved', function(pkg, versions) {
-    console.log(pkg + ': ' + versions.join(', '))
+    console.log(`${pkg}(${versions.length})`)
   })
 
   // Off to the races!

--- a/bin/version-manager.js
+++ b/bin/version-manager.js
@@ -140,7 +140,7 @@ function run(files) {
   runner.on('end', viewer.end.bind(viewer))
 
   runner.on('packageResolved', function(pkg, versions) {
-    console.log(pkg + ': ' + versions.length)
+    console.log(pkg + ': ' + versions.join(', '))
   })
 
   // Off to the races!

--- a/lib/versioned/matrix.js
+++ b/lib/versioned/matrix.js
@@ -158,9 +158,42 @@ function TestMatrix(tests, pkgVersions) {
     })
     return task
   }) : []
+
   this._matrixPos = 0
   this._length = null
 }
+
+/**
+ * Creates an array of formatted strings for a given pkg
+ * under test
+ * [
+ *  'aws-sdk(3): 1.0.0, 1.1.1, 1.3.0',
+ *  'redis(2): 0.0.1, 1.2.4'
+ * ]
+ */
+Object.defineProperty(TestMatrix.prototype, 'versionsByPkg', {
+  get: function() {
+    if (!this._versionsByPkg) {
+      const versionMatrix = this._matrix.reduce((accum, tests) => {
+        tests.packages.forEach((pkg) => {
+          if (!accum.hasOwnProperty(pkg.name)) {
+            accum[pkg.name] = []
+          }
+
+          const versions = pkg.versions.filter((version) => !accum[pkg.name].includes(version))
+          accum[pkg.name].push(...versions)
+        })
+        return accum
+      }, {})
+
+      this._versionsByPkg = Object.entries(versionMatrix)
+        .map(([key, versions]) => `${key}(${versions.length}): ${versions.join(', ')}`)
+    }
+
+    return this._versionsByPkg
+  }
+})
+
 
 Object.defineProperty(TestMatrix.prototype, 'length', {
   get: function() {

--- a/lib/versioned/printers/printer.js
+++ b/lib/versioned/printers/printer.js
@@ -31,6 +31,7 @@ function TestPrinter(tests, opts) {
 
   this.interval = setInterval(this.maybePrint.bind(this), opts.refresh)
 }
+
 TestPrinter.HR = HR
 
 TestPrinter.prototype.maybePrint = function() {
@@ -71,6 +72,22 @@ TestPrinter.prototype._printError = function(test) {
   /* eslint-enable no-console */
 }
 
+/**
+ * Formats a list of all packages run for a given test suite
+ * @param {Test} test
+ */
+TestPrinter.prototype._listPackages = function(test) {
+  return `
+   Packages:
+    ${test.matrix.versionsByPkg.join('\n    ')}
+  `
+}
+
+/**
+ * Formats the stdout for a given test suite as it is running
+ * @param {string} testDir path to test
+ * @return {string} formatted string for the output of a given test iteration
+ */
 TestPrinter.prototype._formatTest = function(testDir) {
   var test = this.tests[testDir].test
   var status = this.tests[testDir].status
@@ -89,16 +106,19 @@ TestPrinter.prototype._formatTest = function(testDir) {
 
     testName = testDir.grey
     result = '\u2713'.green     // checkmark
-    status = ('(' + test.matrix.length + ') ' + duration).grey
+
+    status = `(${test.matrix.length}) ${duration} ${this._listPackages(test)}`.grey
   } else if (status === 'error' || status === 'failure') {
     result = '\u2716'.red       // x mark
     testName = testName.red
-    status = 'run ' + test.runs + ' of ' + test.matrix.length + ': ' + (status.red)
+
+    status = `run ${test.runs} of ${test.matrix.length}: \
+    ${status.red} ${this._listPackages(test).red}`
   } else {
     testName = testName.grey
-    status = 'run ' + test.runs + ' of ' + test.matrix.length + ': ' + (status.cyan)
+    status = `run ${test.runs} of ${test.matrix.length}: ${status.cyan}`
   }
-  return ' ' + result + ' ' + testName + ' ' + status
+  return ` ${result} ${testName} ${status}`
 }
 
 TestPrinter.prototype._isFailure = function(status) {

--- a/tests/unit/versioned/matrix.tap.js
+++ b/tests/unit/versioned/matrix.tap.js
@@ -67,6 +67,14 @@ tap.test('TestMatrix methods and members', function(t) {
     t.end()
   })
 
+  t.test('TestMatrix#versionsByPkg', function(t) {
+    t.deepEqual(matrix.versionsByPkg,
+      ['redis(3): 1.2.3, 1.3.4, 2.0.1'],
+      'should properly format each pkg -> version matrix'
+    )
+    t.end()
+  })
+
   t.test('TestMatrix#peek', function(t) {
     var peek = matrix.peek()
     t.deepEqual(peek, {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Enumerates versions of every module being tested

## Links
Do I need to create a ticket for this?

## Details
Here's an example output from `node-newrelic`

```sh
@koa/router: 8.0.8, 9.4.0, 10.0.0
koa: 0.21.1, 1.7.0, 2.13.1
koa-route: 1.1.4, 2.4.2, 3.2.0
aws-sdk: 1.18.0, 2.899.0
koa-router: 1.6.1, 2.4.4, 3.8.0, 4.3.2, 5.4.2, 6.2.0, 7.4.0, 8.0.8, 9.4.0, 10.0.0
amazon-dax-client: 1.2.5
amqplib: 0.7.1
bluebird: 0.11.6, 1.2.4, 2.11.0, 3.7.2
continuation-local-storage: 0.1.1, 1.1.1, 2.6.2, 3.2.1
connect: 0.5.10, 1.9.2, 2.30.2, 3.7.0
director: 1.2.8
express: 0.14.1, 1.0.8, 2.5.11, 3.21.2, 4.17.1
superagent: 0.21.0, 1.8.5, 2.3.0, 3.8.3, 4.1.0, 5.3.1, 6.1.0
express-enrouten: 0.3.0, 1.3.0
cassandra-driver: 1.0.3, 2.2.2, 3.6.0, 4.6.2
ejs: 0.8.8, 1.0.0, 2.7.4, 3.1.6
generic-pool: 1.0.12, 2.5.4, 3.7.8
fastify: 0.43.0, 1.14.6, 2.15.3, 3.15.1
hapi: 0.16.0, 1.20.0, 2.6.0, 3.1.0, 4.1.4, 5.1.0, 6.11.1, 7.5.3, 8.8.1, 9.5.1, 10.5.0, 11.1.4, 12.1.0, 13.5.3, 14.2.0, 15.2.0, 16.7.0, 17.8.5, 18.1.0
@hapi/hapi: 17.9.0, 18.4.1, 19.2.0, 20.1.2
vision: 1.2.2, 2.0.1, 3.0.0, 4.1.1, 5.4.4
mysql: 0.9.6, 2.18.1
ioredis: 0.5.0, 1.15.1, 2.5.0, 3.2.2, 4.27.2
mongodb: 0.9.9, 1.4.40, 2.2.36, 3.6.6
pg: 0.15.1, 1.3.0, 2.11.2, 3.6.4, 4.5.7, 5.2.1, 6.4.2, 7.18.2, 8.6.0
mysql2: 0.15.8, 1.7.0, 2.2.5
restify-errors: 2.6.1, 3.1.0, 4.3.0, 5.0.0, 6.1.1, 7.0.0, 8.0.2
pg-native: 0.5.2, 1.10.1, 2.2.0, 3.0.0
restify: 0.5.7, 1.4.4, 2.8.5, 3.0.3, 4.3.4, 5.2.1, 6.4.0, 7.7.0, 8.5.1
redis: 0.12.1, 1.0.0, 2.8.0, 3.1.2
```
