### PR TITLE
adding node 16 in version matrix, and see what breaks

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -26,7 +26,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1,6 +1,6 @@
 name: Test Utilities CI
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   lint:

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "publish-docs": "./bin/publish-docs.sh",
     "lint": "eslint *.js lib/*",
     "test": "npm run unit",
-    "unit": "tap tests/unit/*.tap.js tests/unit/*/*.tap.js"
+    "unit": "tap tests/unit/*.tap.js tests/unit/*/*.tap.js",
+    "prepare": "husky install"
   },
   "bin": {
     "versioned-tests": "./bin/version-manager.js"

--- a/tests/unit/versioned/test.tap.js
+++ b/tests/unit/versioned/test.tap.js
@@ -133,10 +133,17 @@ tap.test('Test methods and members', function(t) {
       t.notOk(testRun.failed, 'should not be marked as failed')
 
       t.match(testRun.stdout, new RegExp([
-        '(?:\\+\\s|mock-tests@1\\.0\\.0 /.+?/tests/unit/versioned/mock-tests\n',
-        '└── )?redis@1\\.0\\.0.*?\n?',
+        // pre-npm 7 shows the package + redis@1.0.0
+        '(?:\\+\\s+redis@1\\.0\\.0.*)?\n?',
+        // pre npm 7 if running tests on fresh checkout
+        '(?:\nadded \\d+ packages? from \\d contributor in \\d(?:\\.\\d+)?s)?\n?',
+        // pre npm 7 if running tests that already has tests/unit/versioned/mock-tests/node_modules
         '(?:\nupdated \\d+ packages? in \\d(?:\\.\\d+)?s)?\n?',
-        '(?:\nfound \\d+ vulnerabilities)?\n?',
+        // npm 7 + if running tests on fresh checkout
+        '(?:\nadded \\d+ packages? in \\d(?:\\.\\d+)?s)?\n?',
+        // npm 7 + when running tests that already have tests/unit/versioned/mock-tests/node_modules
+        '(?:\nup to date in \\d(?:\\.\\d+)?s)?\n?',
+        // stdout from loading the fake module
         '\nstdout - redis\\.mock\\.js\n'
       ].join('')), 'should have expected stdout')
 
@@ -211,8 +218,17 @@ tap.test('Test run with allPkgs true', function(t) {
   var testRun = test.run()
   testRun.on('end', function() {
     t.match(testRun.stdout, new RegExp([
-      '\\+ redis@1\\.0\\.0.*?\n?',
+      // pre-npm 7 shows the package + redis@1.0.0
+      '(?:\\+\\s+redis@1\\.0\\.0.*)?\n?',
+      // pre npm 7 if running tests on fresh checkout
+      '(?:\nadded \\d+ packages? from \\d contributor in \\d(?:\\.\\d+)?s)?\n?',
+      // pre npm 7 if running tests that already has tests/unit/versioned/mock-tests/node_modules
       '(?:\nupdated \\d+ packages? in \\d(?:\\.\\d+)?s)?\n?',
+      // npm 7 + if running tests on fresh checkout
+      '(?:\nadded \\d+ packages? in \\d(?:\\.\\d+)?s)?\n?',
+      // npm 7 + when running tests that already have tests/unit/versioned/mock-tests/node_modules
+      '(?:\nup to date in \\d(?:\\.\\d+)?s)?\n?',
+      // stdout from loading the fake module
       '\nstdout - redis\\.mock\\.js\n'
     ].join('')), 'should have expected stdout from redis.mock.js')
     t.equal(testRun.stderr, 'stderr - redis.mock.js\n',
@@ -222,10 +238,19 @@ tap.test('Test run with allPkgs true', function(t) {
 
     nextRun.on('end', function() {
       t.match(nextRun.stdout, new RegExp([
-        '\\+ redis@1\\.0\\.0.*?\n?',
+        // pre-npm 7 shows the package + redis@1.0.0
+        '(?:\\+\\s+redis@1\\.0\\.0.*)?\n?',
+        // pre npm 7 if running tests on fresh checkout
+        '(?:\nadded \\d+ packages? from \\d contributor in \\d(?:\\.\\d+)?s)?\n?',
+        // pre npm 7 if running tests that already has tests/unit/versioned/mock-tests/node_modules
         '(?:\nupdated \\d+ packages? in \\d(?:\\.\\d+)?s)?\n?',
+        // npm 7 + if running tests on fresh checkout
+        '(?:\nadded \\d+ packages? in \\d(?:\\.\\d+)?s)?\n?',
+        // npm 7 + when running tests that already have tests/unit/versioned/mock-tests/node_modules
+        '(?:\nup to date in \\d(?:\\.\\d+)?s)?\n?',
+        // stdout from loading the fake module
         '\nstdout - other\\.mock\\.js\n'
-      ].join('')), 'should have expected stdout fromt other.mock.js')
+      ].join('')), 'should have expected stdout from other.mock.js')
       t.match(nextRun.stderr, new RegExp([
         'stderr - other\\.mock\\.js',
         'Failed to execute test: Error: Failed to execute node'


### PR DESCRIPTION
PR for Node 16 support research

## Proposed Release Notes
 * Added Node.js 16 CI support
 * Loosened assertions to make integration tests pass on both npm v6 and v7