### PR TITLE
only output versions when tests fail and after run

### DIFF
--- a/lib/versioned/matrix.js
+++ b/lib/versioned/matrix.js
@@ -164,38 +164,6 @@ function TestMatrix(tests, pkgVersions) {
   this._length = null
 }
 
-/**
- * Creates an array of formatted strings for a given pkg
- * under test
- * [
- *  'aws-sdk(3): 1.0.0, 1.1.1, 1.3.0',
- *  'redis(2): 0.0.1, 1.2.4'
- * ]
- */
-Object.defineProperty(TestMatrix.prototype, 'versionsByPkg', {
-  get: function versionsByPkg() {
-    if (!this._versionsByPkg) {
-      const versionMatrix = this._matrix.reduce((accum, tests) => {
-        tests.packages.forEach((pkg) => {
-          if (!accum.hasOwnProperty(pkg.name)) {
-            accum[pkg.name] = []
-          }
-
-          const versions = pkg.versions.filter((version) => !accum[pkg.name].includes(version))
-          accum[pkg.name].push(...versions)
-        })
-        return accum
-      }, {})
-
-      this._versionsByPkg = Object.entries(versionMatrix).map(
-        ([key, versions]) => `${key}(${versions.length}): ${versions.join(', ')}`
-      )
-    }
-
-    return this._versionsByPkg
-  }
-})
-
 Object.defineProperty(TestMatrix.prototype, 'length', {
   get: function length() {
     if (this._length === null) {

--- a/lib/versioned/printers/printer.js
+++ b/lib/versioned/printers/printer.js
@@ -74,17 +74,6 @@ TestPrinter.prototype._printError = function _printError(test) {
 }
 
 /**
- * Formats a list of all packages run for a given test suite
- * @param {Test} test
- */
-TestPrinter.prototype._listPackages = function _listPackages(test) {
-  return `
-   Packages:
-    ${test.matrix.versionsByPkg.join('\n    ')}
-  `
-}
-
-/**
  * Formats the stdout for a given test suite as it is running
  * @param {string} testDir path to test
  * @return {string} formatted string for the output of a given test iteration
@@ -108,17 +97,15 @@ TestPrinter.prototype._formatTest = function _formatTest(testDir) {
     testName = testDir.grey
     result = '\u2713'.green // checkmark
 
-    status = `(${test.matrix.length}) ${duration} ${this._listPackages(test)}`.grey
+    status = `(${test.matrix.length}) ${duration}`.grey
   } else if (status === 'error' || status === 'failure') {
     result = '\u2716'.red // x mark
     testName = testName.red
 
-    status = `run ${current.packageVersions.join(' ')} (${test.runs} of ${test.matrix.length}): \
-    ${status.red} ${this._listPackages(test).red}`
+    status = `run ${test.runs} of ${test.matrix.length}): ${status.red}`
   } else {
     testName = testName.grey
-    status = `run ${current.packageVersions.join(' ')} (${test.runs} of ${test.matrix.length}): \
-    ${status.cyan}`
+    status = `run ${test.runs} of ${test.matrix.length}): ${status.cyan}`
   }
   return ` ${result} ${testName} ${status}`
 }

--- a/tests/unit/versioned/matrix.tap.js
+++ b/tests/unit/versioned/matrix.tap.js
@@ -9,105 +9,120 @@ var tap = require('tap')
 
 var TestMatrix = require('../../../lib/versioned/matrix')
 
-
-tap.test('TestMatrix construction', function(t) {
+tap.test('TestMatrix construction', function (t) {
   var matrix = null
 
-  t.doesNotThrow(function() {
-    matrix = new TestMatrix([{
-      engines: {node: '<0.1.0'}, // Purposefully excluding everything.
-      dependencies: {redis: '*'},
-      files: ['redis.tap.js', 'other.tap.js']
-    }, {
-      dependencies: {redis: '>=1.0.0'},
-      files: ['redis.tap.js', 'other.tap.js']
-    }], {
-      bluebird: ['1.0.8', '1.1.1', '1.2.4', '2.0.7'],
-      redis: ['1.2.3', '1.3.4', '2.0.1']
-    })
+  t.doesNotThrow(function () {
+    matrix = new TestMatrix(
+      [
+        {
+          engines: { node: '<0.1.0' }, // Purposefully excluding everything.
+          dependencies: { redis: '*' },
+          files: ['redis.tap.js', 'other.tap.js']
+        },
+        {
+          dependencies: { redis: '>=1.0.0' },
+          files: ['redis.tap.js', 'other.tap.js']
+        }
+      ],
+      {
+        bluebird: ['1.0.8', '1.1.1', '1.2.4', '2.0.7'],
+        redis: ['1.2.3', '1.3.4', '2.0.1']
+      }
+    )
   }, 'should construct without erroring')
 
   t.type(matrix, TestMatrix, 'should construct a TestMatrix')
   t.end()
 })
 
-tap.test('TestMatrix methods and members', function(t) {
+tap.test('TestMatrix methods and members', function (t) {
   t.autoend()
 
   var matrix = null
 
-  t.beforeEach(function() {
-    matrix = new TestMatrix([{
-      engines: {node: '<0.1.0'}, // Purposefully excluding everything.
-      dependencies: {redis: '*'},
-      files: ['redis.tap.js', 'other.tap.js']
-    }, {
-      dependencies: {redis: '>=1.0.0'},
-      files: ['redis.tap.js', 'other.tap.js']
-    }], {
-      bluebird: ['1.0.8', '1.1.1', '1.2.4', '2.0.7'],
-      redis: ['1.2.3', '1.3.4', '2.0.1']
-    })
+  t.beforeEach(function () {
+    matrix = new TestMatrix(
+      [
+        {
+          engines: { node: '<0.1.0' }, // Purposefully excluding everything.
+          dependencies: { redis: '*' },
+          files: ['redis.tap.js', 'other.tap.js']
+        },
+        {
+          dependencies: { redis: '>=1.0.0' },
+          files: ['redis.tap.js', 'other.tap.js']
+        }
+      ],
+      {
+        bluebird: ['1.0.8', '1.1.1', '1.2.4', '2.0.7'],
+        redis: ['1.2.3', '1.3.4', '2.0.1']
+      }
+    )
   })
 
-  t.test('TestMatrix#length', function(t) {
+  t.test('TestMatrix#length', function (t) {
     t.type(matrix.length, 'number', 'should be a number')
-    t.equal(
-      matrix.length, 6,
-      'should be the cartesian product test files and dependencies'
-    )
+    t.equal(matrix.length, 6, 'should be the cartesian product test files and dependencies')
 
     matrix.next()
     t.equal(matrix.length, 6, 'should be the total length, not remaining')
     t.end()
   })
 
-  t.test('TestMatrix#versionsByPkg', function(t) {
-    t.same(matrix.versionsByPkg,
-      ['redis(3): 1.2.3, 1.3.4, 2.0.1'],
-      'should properly format each pkg -> version matrix'
-    )
-    t.end()
-  })
-
-  t.test('TestMatrix#peek', function(t) {
+  t.test('TestMatrix#peek', function (t) {
     var peek = matrix.peek()
-    t.same(peek, {
-      packages: {redis: '1.2.3'},
-      test: 'redis.tap.js'
-    }, 'should return the next test to execute')
+    t.same(
+      peek,
+      {
+        packages: { redis: '1.2.3' },
+        test: 'redis.tap.js'
+      },
+      'should return the next test to execute'
+    )
 
     t.same(peek, matrix.peek(), 'should not change the state of the matrix')
     t.same(peek, matrix.peek(), 'should never change the state of the matrix')
     t.end()
   })
 
-
-  t.test('TestMatrix#next', function(t) {
+  t.test('TestMatrix#next', function (t) {
     var next = matrix.next()
-    t.same(next, {
-      packages: {redis: '1.2.3'},
-      test: 'redis.tap.js'
-    }, 'should return the next test to execute')
+    t.same(
+      next,
+      {
+        packages: { redis: '1.2.3' },
+        test: 'redis.tap.js'
+      },
+      'should return the next test to execute'
+    )
 
     next = matrix.next()
-    t.same(next, {
-      packages: {redis: '1.2.3'},
-      test: 'other.tap.js'
-    }, 'should advance the state of the matrix')
+    t.same(
+      next,
+      {
+        packages: { redis: '1.2.3' },
+        test: 'other.tap.js'
+      },
+      'should advance the state of the matrix'
+    )
 
     next = matrix.next()
-    t.same(next, {
-      packages: {redis: '1.3.4'},
-      test: 'redis.tap.js'
-    }, 'should advance the package versions when out of test files')
+    t.same(
+      next,
+      {
+        packages: { redis: '1.3.4' },
+        test: 'redis.tap.js'
+      },
+      'should advance the package versions when out of test files'
+    )
 
     // Advance the matrix to the end.
     matrix.next()
     matrix.next()
     matrix.next()
 
-    t.doesNotThrow(function() {
+    t.doesNotThrow(function () {
       t.equal(matrix.next(), null, 'should return null when no more tests available')
       t.equal(matrix.next(), null, 'should keep returning null')
     }, 'should not error when reaching the end of the matrix')


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Changed runner output to only list package versions when a test fails.

## Details
This was introduced in #74 and it causes the stdout of the CI run to be too long and very hard to find the details of the test failures.  I think by adding the package versions at the end only when failed will help cut back on the length of stdout.  I cannot properly test with the agent until this is merged.
