### PR TITLE
Add global samples

### DIFF
--- a/bin/version-manager.js
+++ b/bin/version-manager.js
@@ -28,6 +28,7 @@ cmd
   .option('--minor', 'Iterate over minor versions of packages (default).')
   .option('--patch', 'Iterate over every patch version of packages.')
   .option('-a, --all', 'Installs all packages, not just ones that differ in version')
+  .option('--samples <n>', 'Global samples setting to override what is in tests package', int)
   .action((_testGlobs) => {
     testGlobs = _testGlobs
   })
@@ -137,7 +138,8 @@ function run(files) {
     limit: cmd.jobs,
     installLimit: cmd.install,
     versions: mode,
-    allPkgs: !!cmd.all
+    allPkgs: !!cmd.all,
+    globalSamples: cmd.samples
   })
   runner.on('update', viewer.update.bind(viewer))
   runner.on('end', viewer.end.bind(viewer))

--- a/lib/versioned/matrix.js
+++ b/lib/versioned/matrix.js
@@ -48,8 +48,10 @@ const packager = require('./packager')
  *
  * @param {PackageVersions} pkgVersions
  *  All the package versions needed to flesh out the test descriptors.
+ *
+ * @param {number} globalSamples global override for samples
  */
-function TestMatrix(tests, pkgVersions) {
+function TestMatrix(tests, pkgVersions, globalSamples) {
   // The tests object is an array of objects pairing package version ranges with
   // an array of test files. These look like this:
   //  [{
@@ -105,7 +107,7 @@ function TestMatrix(tests, pkgVersions) {
         }
         task.packages = Object.keys(test.dependencies).map((pkg) => {
           let wantedVersions = test.dependencies[pkg]
-          let samples = null
+          let samples = Infinity
 
           if (typeof wantedVersions === 'object') {
             samples = wantedVersions.samples
@@ -118,6 +120,13 @@ function TestMatrix(tests, pkgVersions) {
             versions: pkgVersions[pkg].filter((v) => {
               return semver.satisfies(v, wantedVersions)
             })
+          }
+
+          // If global samples value provided
+          // use whichever is the least between local samples
+          // and global value
+          if (globalSamples) {
+            samples = Math.min(globalSamples, samples)
           }
 
           // The package versions provided are just the most recent versions of the

--- a/lib/versioned/suite.js
+++ b/lib/versioned/suite.js
@@ -23,7 +23,8 @@ function Suite(testFolders, opts) {
       limit: 1,
       installLimit: 1,
       versions: 'minor',
-      allPkgs: false
+      allPkgs: false,
+      globalSamples: null
     },
     opts
   )
@@ -147,7 +148,7 @@ Suite.prototype._runTests = function _runTests(pkgVersions, cb) {
   // Build and queue all of our test directories. The tests are sorted by number
   // of runs required so the longer tests start sooner.
   this.tests = this.testFolders
-    .map((folder) => new Test(folder, pkgVersions, this.opts.allPkgs))
+    .map((folder) => new Test(folder, pkgVersions, this.opts.allPkgs, this.opts.globalSamples))
     .sort((firstEl, secondEl) => secondEl.matrix.length - firstEl.matrix.length)
   this.tests.forEach((test) => {
     queue.push(test)

--- a/lib/versioned/test.js
+++ b/lib/versioned/test.js
@@ -15,13 +15,13 @@ const TestMatrix = require('./matrix')
 
 const TEST_EXECUTOR = path.resolve(__dirname, './runner.js')
 
-function Test(directory, pkgVersions, allPkgs) {
+function Test(directory, pkgVersions, allPkgs, globalSamples) {
   const pkg = require(path.join(directory, 'package'))
   const dirname = path.basename(directory)
 
   this.name = dirname === 'versioned' ? pkg.name : dirname
   this.directory = directory
-  this.matrix = new TestMatrix(pkg.tests, pkgVersions)
+  this.matrix = new TestMatrix(pkg.tests, pkgVersions, globalSamples)
   this.runs = 0
   this.failed = false
   this.currentRun = null

--- a/tests/unit/versioned/matrix.tap.js
+++ b/tests/unit/versioned/matrix.tap.js
@@ -5,12 +5,12 @@
 
 'use strict'
 
-var tap = require('tap')
+const tap = require('tap')
 
-var TestMatrix = require('../../../lib/versioned/matrix')
+const TestMatrix = require('../../../lib/versioned/matrix')
 
 tap.test('TestMatrix construction', function (t) {
-  var matrix = null
+  let matrix = null
 
   t.doesNotThrow(function () {
     matrix = new TestMatrix(
@@ -36,10 +36,48 @@ tap.test('TestMatrix construction', function (t) {
   t.end()
 })
 
+tap.test(
+  'TestMatrix global samples should only be used when local samples is greater than global',
+  function (t) {
+    const matrix = new TestMatrix(
+      [
+        {
+          dependencies: {
+            'test': {
+              samples: 1,
+              versions: '>=1.0.0'
+            },
+            'dep': {
+              samples: 3,
+              versions: '*'
+            },
+            'string-dep': '*'
+          }
+        }
+      ],
+      {
+        'string-dep': ['0.0.0', '0.0.1', '0.0.2', '100.0.0'],
+        'test': ['1.0.0', '1.0.1', '1.0.2'],
+        'dep': ['0.0.1', '0.0.2', '0.0.3', '1.0.0', '1.0.1', '1.0.2']
+      },
+      2
+    )
+
+    const { packages } = matrix._matrix[0]
+
+    t.same(packages, [
+      { name: 'test', next: 0, versions: ['1.0.2'] },
+      { name: 'dep', next: 0, versions: ['0.0.1', '1.0.2'] },
+      { name: 'string-dep', next: 0, versions: ['0.0.0', '100.0.0'] }
+    ])
+    t.end()
+  }
+)
+
 tap.test('TestMatrix methods and members', function (t) {
   t.autoend()
 
-  var matrix = null
+  let matrix = null
 
   t.beforeEach(function () {
     matrix = new TestMatrix(
@@ -71,7 +109,7 @@ tap.test('TestMatrix methods and members', function (t) {
   })
 
   t.test('TestMatrix#peek', function (t) {
-    var peek = matrix.peek()
+    const peek = matrix.peek()
     t.same(
       peek,
       {
@@ -87,7 +125,7 @@ tap.test('TestMatrix methods and members', function (t) {
   })
 
   t.test('TestMatrix#next', function (t) {
-    var next = matrix.next()
+    let next = matrix.next()
     t.same(
       next,
       {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Added a `--samples` value to CLI to allow an override of sampling for a given test run.  Global sample value will be used when it is less than the samples value set on a given package in the tests stanza
 