### PR TITLE
Attempts to directly install versioned test dependencies when no match

### DIFF
--- a/lib/versioned/matrix.js
+++ b/lib/versioned/matrix.js
@@ -7,8 +7,6 @@
 
 const semver = require('semver')
 
-const packager = require('./packager')
-
 /**
  * @interface TestDescriptor
  * @private
@@ -129,21 +127,25 @@ function TestMatrix(tests, pkgVersions, globalSamples) {
             samples = Math.min(globalSamples, samples)
           }
 
-          // The package versions provided are just the most recent versions of the
-          // packages according to our testing mode (i.e. major, minor, patch). If
-          // none of the latest packages match, then just grab any one that does.
-          // Better to run the test on an older version than not at all.
+          /**
+           * The package versions provided are just the most recent versions of the
+           * packages according to our testing mode (i.e. major, minor, patch). If
+           * none of the latest packages match, then either an older version is requested
+           * or a tag (i.e. latest) is used. Attempt to grab the package as-is.
+           *
+           * Failure to install later will result in failing the test, which is also ideal
+           * VS a warn-only failure that passes CI.
+           */
           if (pkgIterator.versions.length === 0) {
-            const matching = packager.get(pkg, wantedVersions)
+            /* eslint-disable no-console */
+            console.log(
+              'No version match found. Attempting direct install of %s@%s',
+              pkg,
+              wantedVersions
+            )
+            /* eslint-enable no-console */
 
-            // If we still have no versions, report such and move on.
-            if (matching.length === 0) {
-              /* eslint-disable no-console */
-              console.error('Warning: no versions match %s@%s', pkg, wantedVersions)
-              /* eslint-enable no-console */
-            } else {
-              pkgIterator.versions = [matching[matching.length - 1]]
-            }
+            pkgIterator.versions = [wantedVersions]
           }
 
           // Sample the versions down to the limit if applicable

--- a/tests/unit/versioned/matrix.tap.js
+++ b/tests/unit/versioned/matrix.tap.js
@@ -168,3 +168,36 @@ tap.test('TestMatrix methods and members', function (t) {
     t.end()
   })
 })
+
+tap.test('Should return raw dependency version when does not directly match any retrieved', (t) => {
+  const tests = [
+    {
+      dependencies: { redis: 'latest' },
+      files: ['redis.tap.js', 'other.tap.js']
+    },
+    {
+      dependencies: { redis: 'random' },
+      files: ['redis.tap.js', 'other.tap.js']
+    }
+  ]
+
+  const retrievedPackageVersions = {
+    redis: ['1.2.3', '1.3.4', '2.0.1']
+  }
+
+  const matrix = new TestMatrix(tests, retrievedPackageVersions)
+
+  const test1 = matrix.next()
+  t.equal(test1.packages.redis, 'latest')
+
+  const test2 = matrix.next()
+  t.equal(test2.packages.redis, 'latest')
+
+  const test3 = matrix.next()
+  t.equal(test3.packages.redis, 'random')
+
+  const test4 = matrix.next()
+  t.equal(test4.packages.redis, 'random')
+
+  t.end()
+})


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Added ability to run versioned tests against version tags. For example: `newrelic@latest`.

  When a version such as `package@latest` is specified in the versioned test `package.json` declarations, it won't directly satisfy semver matches against the package versions manually pulled down and cached. The runner now attempts to directly install the configured version, which also results in a test failure if the package fails to install. Previously, failure to be able to install a dependency would log a warning and then just not run any tests and let CI pass.

## Links

* Enables current proposed solution to: https://github.com/newrelic/newrelic-node-apollo-server-plugin/issues/138

## Details

To remove a forked code-path, I also do this for the case where the versions would match an older version of the package but doesn't for a configuration such as running --major. This ends up running against just the latest of the older versions based on npm install behavior instead of iterating through the cache.

The result of going to npm install regardless on failing matches could result in some slowness but the known failure seems like a valid trade-off.

### New Success Behavior

```
No version match found. Attempting direct install of @apollo/federation@latest
No version match found. Attempting direct install of @apollo/gateway@latest
No version match found. Attempting direct install of @opentelemetry/api@latest
No version match found. Attempting direct install of apollo-server@latest
No version match found. Attempting direct install of fastify@3.17.0
===============================================================
 ✓ apollo-federation (5) 12s
 ✓ apollo-server (12) 47s
 ✓ apollo-server-express (10) 41s
 ✓ apollo-server-fastify (10) 40s
 ✓ apollo-server-hapi (5) 10s
 ✓ apollo-server-koa (10) 39s
 ✓ apollo-server-lambda (10) 33s
===============================================================
PASS
```

### Previous Failure Behavior

```
Warning: no versions match @apollo/federation@bad
Warning: no versions match @apollo/gateway@latest
Warning: no versions match @opentelemetry/api@latest
Warning: no versions match apollo-server@latest

   apollo-federation
 ✓ apollo-server (12) 42s
 ✓ apollo-server-express (10) 38s
 ✓ apollo-server-fastify (10) 37s
 ✓ apollo-server-hapi (5) 9s
 ✓ apollo-server-koa (10) 35s
 ✓ apollo-server-lambda (10) 31s

===============================================================
PASS
```

### New Failure Behavior

```
No version match found. Attempting direct install of @apollo/federation@bad
No version match found. Attempting direct install of @apollo/gateway@latest
No version match found. Attempting direct install of @opentelemetry/api@latest
No version match found. Attempting direct install of apollo-server@latest
No version match found. Attempting direct install of fastify@3.17.0
===============================================================
 • apollo-federation/segments.test.js run 1 of 5): installing
 ✓ apollo-server (12) 47s
 ✓ apollo-server-express (10) 41s
 ✓ apollo-server-fastify (10) 41s
 • apollo-server-hapi/transaction-naming.test.js run 2 of 5): running
 ✓ apollo-server-koa (10) 39s
 ✓ apollo-server-lambda (10) 34s
===============================================================
===============================================================
/Users/mgoin/Documents/development/michaelgoin/newrelic-node-apollo-server-plugin/tests/versioned/apollo-federation/segments.test.js @apollo/federation@bad @apollo/gateway@latest @opentelemetry/api@latest apollo-server@latest
stdout

---------------------------------------------------------------
stderr
npm ERR! code ETARGET
npm ERR! notarget No matching version found for @apollo/federation@bad.
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/mgoin/.npm/_logs/2021-10-15T22_35_51_674Z-debug.log
Clearing cache and retrying failed install...
npm ERR! As of npm@5, the npm cache self-heals from corruption issues
npm ERR!   by treating integrity mismatches as cache misses.  As a result,
npm ERR!   data extracted from the cache is guaranteed to be valid.  If you
npm ERR!   want to make sure everything is consistent, use `npm cache verify`
npm ERR!   instead.  Deleting the cache can only make npm go slower, and is
npm ERR!   not likely to correct any problems you may be encountering!
npm ERR! 
npm ERR!   On the other hand, if you're debugging an issue with the installer,
npm ERR!   or race conditions that depend on the timing of writing to an empty
npm ERR!   cache, you can use `npm install --cache /tmp/empty-cache` to use a
npm ERR!   temporary cache instead of nuking the actual one.
npm ERR! 
npm ERR!   If you're sure you want to delete the entire cache, rerun this command
npm ERR!   with --force.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/mgoin/.npm/_logs/2021-10-15T22_35_57_105Z-debug.log
Failed to clear cache: Error: Failed to execute npm cache clean
    at ChildProcess.exitHandler (/Users/mgoin/Documents/development/michaelgoin/node-test-utilities/lib/versioned/runner.js:149:17)
    at ChildProcess.emit (node:events:394:28)
    at Process.ChildProcess._handle.onexit (node:internal/child_process:290:12)

===============================================================
===============================================================
 ✖ apollo-federation/segments.test.js run 1 of 5): failure
 ✓ apollo-server (12) 47s
 ✓ apollo-server-express (10) 41s
 ✓ apollo-server-fastify (10) 41s
 ✓ apollo-server-hapi (5) 11s
 ✓ apollo-server-koa (10) 39s
 ✓ apollo-server-lambda (10) 34s
===============================================================
FAIL (1)
   packages: @apollo/federation@bad, @apollo/gateway@latest, @opentelemetry/api@latest, apollo-server@latest file: /Users/mgoin/Documents/development/michaelgoin/newrelic-node-apollo-server-plugin/tests/versioned/apollo-federation/segments.test.js
```