### PR TITLE
Adds getter for a test shim instance

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -12,6 +12,7 @@ const Agent = require(newRelicLoc + '/lib/agent')
 const API = require(newRelicLoc + '/api')
 const configurator = require(newRelicLoc + '/lib/config')
 const shimmer = require(newRelicLoc + '/lib/shimmer')
+const Shim = require(newRelicLoc + '/lib/shim/shim')
 
 module.exports = TestAgent
 
@@ -182,11 +183,23 @@ TestAgent.prototype.getTransaction = function getTransaction() {
  * Gets an agent API instance for test instance.
  */
 TestAgent.prototype.getAgentApi = function getAgentApi() {
-  if (!this.agentApi) {
+  if (!this._agentApi) {
     this._agentApi = new API(this.agent)
   }
 
   return this._agentApi
+}
+
+/**
+ * Gets a shim instance for the test instance.
+ * @returns The existing or newly created shim.
+ */
+TestAgent.prototype.getShim = function getShim() {
+  if (!this._shim) {
+    this._shim = new Shim(this.agent, 'Test Agent')
+  }
+
+  return this._shim
 }
 
 /**

--- a/tests/unit/agent.tap.js
+++ b/tests/unit/agent.tap.js
@@ -163,5 +163,15 @@ tap.test('TestAgent instance', (t) => {
     t.end()
   })
 
+  t.test('TestAgent#getShim', (t) => {
+    const shim = helper.getShim()
+
+    t.ok(shim)
+    t.equal(shim.agent, helper.agent)
+    t.equal(shim.moduleName, 'Test Agent')
+
+    t.end()
+  })
+
   t.autoend()
 })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Added `getShim` method for retrieving a test Shim instance.

  This enables test setup involving instrumentation like scenarios (adding segments, etc.) without reaching into the internal tracer.

## Links

## Details

Helps enable removing all usages of tracer from external module test code. Debated adding a method to the helper to abstract the need but went with shim creation since the shim is a public instrumentation API (breaking changes are semver major) and having more examples even in test code seems helpful.
