### PR TITLE
added printing versioned matrix by pkg at the end of test run before the missing tests message

### DIFF
--- a/lib/versioned/matrix.js
+++ b/lib/versioned/matrix.js
@@ -174,6 +174,29 @@ function TestMatrix(tests, pkgVersions, globalSamples) {
   this._matrixPos = 0
   this._length = null
 }
+Object.defineProperty(TestMatrix.prototype, 'versionsByPkg', {
+  get: function versionsByPkg() {
+    if (!this._versionsByPkg) {
+      const versionMatrix = this._matrix.reduce((accum, tests) => {
+        tests.packages.forEach((pkg) => {
+          if (!accum.hasOwnProperty(pkg.name)) {
+            accum[pkg.name] = []
+          }
+
+          const versions = pkg.versions.filter((version) => !accum[pkg.name].includes(version))
+          accum[pkg.name].push(...versions)
+        })
+        return accum
+      }, {})
+
+      this._versionsByPkg = Object.entries(versionMatrix).map(
+        ([key, versions]) => `${key}(${versions.length}): ${versions.join(', ')}`
+      )
+    }
+
+    return this._versionsByPkg
+  }
+})
 
 Object.defineProperty(TestMatrix.prototype, 'length', {
   get: function length() {

--- a/lib/versioned/printers/printer.js
+++ b/lib/versioned/printers/printer.js
@@ -46,7 +46,13 @@ TestPrinter.prototype.printVersionedMatrix = function printVersionedMatrix() {
   console.log('Versions executed\n')
   // eslint-disable-next-line guard-for-in
   for (const pkg in this.tests) {
-    console.log(this.tests[pkg].test.matrix.versionsByPkg.join('\n'))
+    const versions = this.tests[pkg].test.matrix.versionsByPkg
+    if (versions.length) {
+      console.log(`Folder: ${pkg}`)
+      console.log(`\t * ${versions.join('\n\t * ')}`)
+    } else {
+      console.log(`Folder: ${pkg}(SKIPPED)`)
+    }
   }
   console.log(HR)
 }

--- a/lib/versioned/printers/printer.js
+++ b/lib/versioned/printers/printer.js
@@ -42,6 +42,15 @@ TestPrinter.prototype.maybePrint = function maybePrint() {
   }
 }
 
+TestPrinter.prototype.printVersionedMatrix = function printVersionedMatrix() {
+  console.log('Versions executed\n')
+  // eslint-disable-next-line guard-for-in
+  for (const pkg in this.tests) {
+    console.log(this.tests[pkg].test.matrix.versionsByPkg.join('\n'))
+  }
+  console.log(HR)
+}
+
 TestPrinter.prototype.maybePrintMissing = function maybePrintMissing() {
   const missingFiles = {}
   // eslint-disable-next-line guard-for-in
@@ -67,6 +76,7 @@ TestPrinter.prototype.maybePrintMissing = function maybePrintMissing() {
 
 TestPrinter.prototype.end = function end() {
   this.maybePrint()
+  this.printVersionedMatrix()
   this.maybePrintMissing()
   clearInterval(this.interval)
 }

--- a/tests/unit/versioned/matrix.tap.js
+++ b/tests/unit/versioned/matrix.tap.js
@@ -108,6 +108,15 @@ tap.test('TestMatrix methods and members', function (t) {
     t.end()
   })
 
+  t.test('TestMatrix#versionsByPkg', function (t) {
+    t.same(
+      matrix.versionsByPkg,
+      ['redis(3): 1.2.3, 1.3.4, 2.0.1'],
+      'should properly format each pkg -> version matrix'
+    )
+    t.end()
+  })
+
   t.test('TestMatrix#peek', function (t) {
     const peek = matrix.peek()
     t.same(

--- a/tests/unit/versioned/printers/printer.tap.js
+++ b/tests/unit/versioned/printers/printer.tap.js
@@ -100,22 +100,6 @@ tap.test('printVersionedMatrix', function (t) {
       [
         {
           engines: { node: '<0.1.0' },
-          dependencies: { redis: '*' },
-          files: ['redis.tap.js', 'other.tap.js']
-        },
-        {
-          dependencies: { redis: '>=1.0.0' },
-          files: ['redis.tap.js', 'other.tap.js']
-        }
-      ],
-      {
-        redis: ['1.2.3', '1.3.4', '2.0.1']
-      }
-    )
-    const redisMatrix = new TestMatrix(
-      [
-        {
-          engines: { node: '<0.1.0' },
           dependencies: { bluebird: '*' },
           files: ['other.tap.js']
         },
@@ -128,13 +112,73 @@ tap.test('printVersionedMatrix', function (t) {
         bluebird: ['1.0.3', '1.3.4', '2.0.1', '3.8.1', '4.0.0']
       }
     )
+    const redisMatrix = new TestMatrix(
+      [
+        {
+          engines: { node: '<0.1.0' },
+          dependencies: { redis: '*' },
+          files: ['redis.tap.js', 'other.tap.js']
+        },
+        {
+          dependencies: { redis: '>=1.0.0' },
+          files: ['redis.tap.js', 'other.tap.js']
+        }
+      ],
+      {
+        redis: ['1.2.3', '1.3.4', '2.0.1']
+      }
+    )
     printer.tests.bluebird.test = { matrix: bluebirdMatrix }
     printer.tests.redis.test = { matrix: redisMatrix }
     printer.printVersionedMatrix()
     t.same(console.log.args, [
       ['Versions executed\n'],
-      ['redis(3): 1.2.3, 1.3.4, 2.0.1'],
-      ['bluebird(5): 1.0.3, 1.3.4, 2.0.1, 3.8.1, 4.0.0'],
+      ['Folder: bluebird'],
+      ['\t * bluebird(5): 1.0.3, 1.3.4, 2.0.1, 3.8.1, 4.0.0'],
+      ['Folder: redis'],
+      ['\t * redis(3): 1.2.3, 1.3.4, 2.0.1'],
+      ['===============================================================']
+    ])
+    t.end()
+  })
+
+  t.test('should print skipped when no versions for a package exist', (t) => {
+    const bluebirdMatrix = new TestMatrix(
+      [
+        {
+          engines: { node: '<0.1.0' },
+          dependencies: { bluebird: '1.0.0' },
+          files: ['other.tap.js']
+        }
+      ],
+      {
+        bluebird: ['2.0.0']
+      }
+    )
+    const redisMatrix = new TestMatrix(
+      [
+        {
+          engines: { node: '<0.1.0' },
+          dependencies: { redis: '*' },
+          files: ['redis.tap.js', 'other.tap.js']
+        },
+        {
+          dependencies: { redis: '>=1.0.0' },
+          files: ['redis.tap.js', 'other.tap.js']
+        }
+      ],
+      {
+        redis: ['1.2.3', '1.3.4', '2.0.1']
+      }
+    )
+    printer.tests.bluebird.test = { matrix: bluebirdMatrix }
+    printer.tests.redis.test = { matrix: redisMatrix }
+    printer.printVersionedMatrix()
+    t.same(console.log.args, [
+      ['Versions executed\n'],
+      ['Folder: bluebird(SKIPPED)'],
+      ['Folder: redis'],
+      ['\t * redis(3): 1.2.3, 1.3.4, 2.0.1'],
       ['===============================================================']
     ])
     t.end()

--- a/tests/unit/versioned/printers/printer.tap.js
+++ b/tests/unit/versioned/printers/printer.tap.js
@@ -72,4 +72,73 @@ tap.test('maybePrintMissing', function (t) {
   })
 })
 
+tap.test('printVersionedMatrix', function (t) {
+  const TestMatrix = require('../../../../lib/versioned/matrix')
+  t.autoend()
+  let printer = null
+  t.before(() => {
+    sinon.stub(console, 'log')
+  })
+  t.beforeEach(() => {
+    printer = new TestPrinter(
+      [`${MOCK_TEST_DIR}/bluebird/package.json`, `${MOCK_TEST_DIR}/redis/package.json`],
+      { refresh: 100 }
+    )
+  })
+
+  t.afterEach(() => {
+    clearInterval(printer.interval)
+    console.log.resetHistory()
+  })
+
+  t.teardown(() => {
+    console.log.restore()
+  })
+
+  t.test('should print versions by package', (t) => {
+    const bluebirdMatrix = new TestMatrix(
+      [
+        {
+          engines: { node: '<0.1.0' },
+          dependencies: { redis: '*' },
+          files: ['redis.tap.js', 'other.tap.js']
+        },
+        {
+          dependencies: { redis: '>=1.0.0' },
+          files: ['redis.tap.js', 'other.tap.js']
+        }
+      ],
+      {
+        redis: ['1.2.3', '1.3.4', '2.0.1']
+      }
+    )
+    const redisMatrix = new TestMatrix(
+      [
+        {
+          engines: { node: '<0.1.0' },
+          dependencies: { bluebird: '*' },
+          files: ['other.tap.js']
+        },
+        {
+          dependencies: { bluebird: '>=1.0.0' },
+          files: ['other.tap.js']
+        }
+      ],
+      {
+        bluebird: ['1.0.3', '1.3.4', '2.0.1', '3.8.1', '4.0.0']
+      }
+    )
+    printer.tests.bluebird.test = { matrix: bluebirdMatrix }
+    printer.tests.redis.test = { matrix: redisMatrix }
+    printer.printVersionedMatrix()
+    t.same(console.log.args, [
+      ['Versions executed\n'],
+      ['redis(3): 1.2.3, 1.3.4, 2.0.1'],
+      ['bluebird(5): 1.0.3, 1.3.4, 2.0.1, 3.8.1, 4.0.0'],
+      ['===============================================================']
+    ])
+    t.end()
+  })
+})
+
 // eslint-enable no-console


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Added printing list of packages and their versions at the end of a run.

## Links

## Details
Based on an old PR I opened #89, I think I meant to add this but never did.  I noticed we have an issue with package resolution when the range specified does not match the latest version in a package for a given semver major range.  I plan on following up with a fix for that.  Here is the output

```sh
✓ mysql2 (4) 20s
 ✓ pg-post-7 (1) 10s
   pg-pre-7
 ✓ redis (2) 5s
 ✓ restify-post-7 (14) 35s
 ✓ restify-pre-7 (12) 30s
 ✓ superagent-tests (12) 24s
 ✓ undici (1) 6s
 ✓ v2 (9) 38s
 ✓ v3 (13) 1m
===============================================================
Versions executed

aws-sdk(2): 2.2.48, 2.1092.0
amazon-dax-client(1): 1.2.7
@aws-sdk/client-api-gateway(1): 3.54.0
@aws-sdk/client-elasticache(1): 3.54.0
@aws-sdk/client-elastic-load-balancing(1): 3.54.0
@aws-sdk/client-lambda(1): 3.54.0
@aws-sdk/client-rds(1): 3.54.0
@aws-sdk/client-redshift(1): 3.54.0
@aws-sdk/client-rekognition(1): 3.54.0
@aws-sdk/client-s3(1): 3.54.0
@aws-sdk/client-ses(1): 3.54.0
@aws-sdk/client-sns(1): 3.54.0
@aws-sdk/client-sqs(1): 3.54.0
@aws-sdk/client-dynamodb(2): 3.54.0, latest
@aws-sdk/util-dynamodb(1): latest
@aws-sdk/lib-dynamodb(1): 3.54.0
koa(2): 1.7.0, 2.13.4
@koa/router(1): >=8.0.0 <=8.0.2
koa-router(1): 7.4.0
koa-route(1): 3.2.0
superagent(6): 2.3.0, 3.8.3, 4.1.0, 5.3.1, 6.1.0, 7.1.1
amqplib(1): 0.8.0
bluebird(2): 2.11.0, 3.7.2
cassandra-driver(2): 3.6.0, 4.6.3
continuation-local-storage(1): 3.2.1
async-listener(1): 0.6.10
connect(3): 1.9.2, 2.30.2, 3.7.0

express(1): 4.17.3
express-enrouten(1): 1.1
ejs(1): 2.5
fastify(2): 2.15.3, 3.27.4
middie(1): 5.3.0
generic-pool(2): 3.8.2, 2.5.4

ejs(1): 2.5.5
@hapi/hapi(1): 20.2.1
vision(1): 5.4.4

ioredis(2): 3.2.2, 4.28.5
mongodb(3): 2.2.36, 3.7.3, 4.4.1
mysql(1): 2.18.1
generic-pool(1): 2.4
mysql2(1): >=1.3.1 <1.6.2
generic-pool(1): 2.4 <2.5
pg(1): 8.7.3
pg-native(1): 2.2.0

redis(2): 2.8.0, 3.1.2
restify(2): 7.7.0, 8.6.1
express(1): 4.16
restify-errors(1): 6.1.1
restify(2): 5.2.1, 6.4.0
express(1): 4.16
restify-errors(1): 6.1.1
undici(1): 4.15.1
===============================================================
The following test suites had test files that were not included in their package.json:

restify-pre-7:
	- /Users/revans/code/node-newrelic/test/versioned/restify/restify-pre-7/with-express.tap.js
PASS

```
