### PR TITLE
fixed how we resolve versions with semver ranges, static versions and `latest` keyword

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -134,35 +134,52 @@ util.getDelocalizedHostname = function getDelocalizedHostname(hostname) {
  *
  * @param {string[]} versions - A list of version numbers
  * @param {string} mode - Either "major" or "minor", ("patch" will return the
+ * @param {object} meta - metadata for a given packages {semverRanges, latest, staticVersions}
  * same array of versions)
  */
-util.maxVersionPerMode = function maxVersionPerMode(versions, mode) {
+util.maxVersionPerMode = function maxVersionPerMode(versions, mode, meta) {
+  const semverRanges = meta.semverRanges.join(' || ')
+  const includeLatest = meta.latest
+  const { staticVersions } = meta
   // Remove versions that don't fit the semantic versioning convention
   versions = versions.filter((version) => {
     return /^\d+\.\d+\.\d+$/.test(version)
   })
 
-  // Creates an object where the key is the version number up to the mode
-  // specified, and the value is the highest version in that set.
-  const greatestVersionInMode = {}
-  versions.forEach((version) => {
-    // Get the version number up to the mode specified. (turns 1.0.1 into 1 if
-    // mode is major)
-    let versionMode = version
-    if (mode === 'major') {
-      versionMode = /^(\d+)/.exec(version)[1]
-    } else if (mode === 'minor') {
-      versionMode = /^(\d+\.\d+)/.exec(version)[1]
+  if (mode === 'patch') {
+    return versions
+  }
+
+  const versionRegex = mode === 'major' ? /^(\d+)/ : /^(\d+\.\d+)/
+  const greatestVersions = []
+  const latestVersion = versions[versions.length - 1]
+
+  const versionsByMajor = versions.reduce((previousValue, version) => {
+    const versionMode = versionRegex.exec(version)[1]
+    if (!previousValue.hasOwnProperty(versionMode)) {
+      previousValue[versionMode] = []
     }
 
-    // Keep track of the greatest version version in this mode
-    const greatest = greatestVersionInMode[versionMode]
-    if (!greatest || semver.gt(version, greatest)) {
-      greatestVersionInMode[versionMode] = version
+    if (staticVersions.includes(version)) {
+      greatestVersions.push(version)
     }
-  })
 
-  // Return just the greatest version numbers of each version "mode"
-  const greatestVersions = Object.values(greatestVersionInMode)
+    previousValue[versionMode].push(version)
+    return previousValue
+  }, {})
+
+  // put the latest first to avoid duplicates of the same version
+  // when looking for max within a semver range
+  if (includeLatest) {
+    greatestVersions.push(latestVersion)
+  }
+
+  for (const [, value] of Object.entries(versionsByMajor)) {
+    const maxVersion = semver.maxSatisfying(value, semverRanges)
+    if (maxVersion && !greatestVersions.includes(maxVersion)) {
+      greatestVersions.push(maxVersion)
+    }
+  }
+
   return greatestVersions
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -134,7 +134,7 @@ util.getDelocalizedHostname = function getDelocalizedHostname(hostname) {
  *
  * @param {string[]} versions - A list of version numbers
  * @param {string} mode - Either "major" or "minor", ("patch" will return the
- * @param {object} meta - metadata for a given packages {semverRanges, latest, staticVersions}
+ * @param {object} meta - metadata for a given package {semverRanges, latest, staticVersions}
  * same array of versions)
  */
 util.maxVersionPerMode = function maxVersionPerMode(versions, mode, meta) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -174,12 +174,12 @@ util.maxVersionPerMode = function maxVersionPerMode(versions, mode, meta) {
     greatestVersions.push(latestVersion)
   }
 
-  for (const [, value] of Object.entries(versionsByMajor)) {
+  Object.values(versionsByMajor).forEach((value) => {
     const maxVersion = semver.maxSatisfying(value, semverRanges)
     if (maxVersion && !greatestVersions.includes(maxVersion)) {
       greatestVersions.push(maxVersion)
     }
-  }
+  })
 
   return greatestVersions
 }

--- a/lib/versioned/matrix.js
+++ b/lib/versioned/matrix.js
@@ -70,8 +70,8 @@ function TestMatrix(tests, pkgVersions, globalSamples) {
   // The pkgVersions object is a pairing of package names to arrays of versions
   // that look like this:
   //  {
-  //    "bluebird": ["1.0", "1.1", "1.2", "1.3"],
-  //    "redis": ["1.2", "1.3", "2.0"]
+  //    "bluebird": { "versions": ["1.0", "1.1", "1.2", "1.3"], "latest": "1.3"},
+  //    "redis": { "versions": ["1.2", "1.3", "2.0"], "latest": "2.0" }
   //  }
   //
   // We want to convert the tests array into an array of objects with package
@@ -115,8 +115,11 @@ function TestMatrix(tests, pkgVersions, globalSamples) {
           const pkgIterator = {
             name: pkg,
             next: 0,
-            versions: pkgVersions[pkg].filter((v) => {
-              return semver.satisfies(v, wantedVersions)
+            versions: pkgVersions[pkg].versions.filter((v) => {
+              // return the latest version when semver range is `latest` otherwsie check if semver is sastisfied
+              return wantedVersions === 'latest'
+                ? pkgVersions[pkg].latest === v
+                : semver.satisfies(v, wantedVersions)
             })
           }
 
@@ -130,10 +133,10 @@ function TestMatrix(tests, pkgVersions, globalSamples) {
           /**
            * The package versions provided are just the most recent versions of the
            * packages according to our testing mode (i.e. major, minor, patch). If
-           * none of the latest packages match, then either an older version is requested
-           * or a tag (i.e. latest) is used. Attempt to grab the package as-is.
+           * none of the latest packages match, then an older version is requested
+           * or a tag is used. Attempt to grab the package as-is.
            *
-           * Failure to install later will result in failing the test, which is also ideal
+           * Failure tuo install later will result in failing the test, which is also ideal
            * VS a warn-only failure that passes CI.
            */
           if (pkgIterator.versions.length === 0) {

--- a/lib/versioned/matrix.js
+++ b/lib/versioned/matrix.js
@@ -136,7 +136,7 @@ function TestMatrix(tests, pkgVersions, globalSamples) {
            * none of the latest packages match, then an older version is requested
            * or a tag is used. Attempt to grab the package as-is.
            *
-           * Failure tuo install later will result in failing the test, which is also ideal
+           * Failure to install later will result in failing the test, which is also ideal
            * VS a warn-only failure that passes CI.
            */
           if (pkgIterator.versions.length === 0) {

--- a/lib/versioned/printers/printer.js
+++ b/lib/versioned/printers/printer.js
@@ -12,6 +12,8 @@ const util = require('../../util')
 
 const HR = '==============================================================='
 
+/* eslint-disable no-console */
+
 function TestPrinter(tests, opts) {
   this.tests = tests
     .map((tPath) => {
@@ -67,7 +69,6 @@ TestPrinter.prototype.maybePrintMissing = function maybePrintMissing() {
     }
   }
 
-  // eslint-disable no-console
   if (Object.keys(missingFiles).length) {
     console.log(
       `The following test suites had test files that were not included in their package.json:\n`.red
@@ -77,7 +78,6 @@ TestPrinter.prototype.maybePrintMissing = function maybePrintMissing() {
       console.log(`${name}:\n\t- ${missingFiles[name].join('\n\t- ')}`.red)
     }
   }
-  // eslint-enable no-console
 }
 
 TestPrinter.prototype.end = function end() {
@@ -101,7 +101,6 @@ TestPrinter.prototype._doUpdate = function _doUpdate(test, status, shouldPrint) 
 }
 
 TestPrinter.prototype._printError = function _printError(test) {
-  /* eslint-disable no-console */
   console.log(HR.grey)
   console.log(test.currentRun.test.red.bold, test.currentRun.packageVersions.join(' '))
   console.log('stdout'.underline)
@@ -110,7 +109,6 @@ TestPrinter.prototype._printError = function _printError(test) {
   console.log('stderr'.underline)
   console.log(test.stderr)
   console.log(HR.grey)
-  /* eslint-enable no-console */
 }
 
 /**
@@ -153,5 +151,7 @@ TestPrinter.prototype._formatTest = function _formatTest(testDir) {
 TestPrinter.prototype._isFailure = function _isFailure(status) {
   return status === 'failure' || status === 'error'
 }
+
+/* eslint-enable no-console */
 
 module.exports = TestPrinter

--- a/lib/versioned/suite.js
+++ b/lib/versioned/suite.js
@@ -17,6 +17,7 @@ const Test = require('./test')
 
 function Suite(testFolders, opts) {
   this.testFolders = testFolders
+  this.pkgsMeta = {}
   this.opts = _.extend(
     {},
     {
@@ -33,23 +34,32 @@ function Suite(testFolders, opts) {
 }
 util.inherits(Suite, EventEmitter)
 
-Suite.prototype.start = function start(cb) {
-  // Figure out the union of all packages required by all of the tests.
-  let packages = new Set()
+/**
+ * Builds the metadata for every package in the appropriate test folders.
+ * This will iterate over every test folder, get the package.json,
+ * iterate over every tests array and find semver ranges,
+ * latest flag and static versions for every unique package.
+ */
+Suite.prototype.prepare = function prepare() {
   this.testFolders.forEach((folder) => {
     const testPackage = require(path.join(folder, 'package'))
     if (testPackage.tests) {
       testPackage.tests.forEach((test) => {
         const dependencies = Object.keys(test.dependencies)
-        dependencies.forEach((dep) => packages.add(dep))
+        dependencies.forEach((dep) => {
+          const versions = getPkgVersions(test.dependencies[dep])
+          this._buildPkgMeta(dep, versions)
+        })
       })
     }
   })
-  packages = Array.from(packages)
+}
 
+Suite.prototype.start = function start(cb) {
+  this.prepare()
   const self = this
   a.waterfall(
-    [this._mapPackagesToVersions.bind(this, packages), this._runTests.bind(this)],
+    [this._mapPackagesToVersions.bind(this), this._runTests.bind(this)],
     function finishHandler(err) {
       if (err && (!cb || self.listenerCount('error'))) {
         self.emit('error', err)
@@ -60,7 +70,36 @@ Suite.prototype.start = function start(cb) {
   )
 }
 
-Suite.prototype._mapPackagesToVersions = function _mapPackagesToVersions(packages, cb) {
+/**
+ * The versions for a package can be a string or object
+ * return the appropriate one
+ */
+function getPkgVersions(dep) {
+  return typeof dep === 'object' ? dep.versions : dep
+}
+
+/**
+ * Creates a key in the pkgsMeta for every package.  Each package
+ * will have an array of semver ranges, a latest flag(if a test wants only the latest of the package), and static versions.
+ */
+Suite.prototype._buildPkgMeta = function _buildPkgMeta(name, versions) {
+  if (!this.pkgsMeta.hasOwnProperty(name)) {
+    this.pkgsMeta[name] = { semverRanges: [], latest: false, staticVersions: [] }
+  }
+
+  if (versions === 'latest') {
+    this.pkgsMeta[name].latest = true
+    // Static version if it starts with a digit and does not end in `.x`
+    // i.e - 3.0.0(static), 3.x(not static)
+  } else if (versions.match(/^\d.*[^\.x]$/)) {
+    this.pkgsMeta[name].staticVersions.push(versions)
+  } else {
+    this.pkgsMeta[name].semverRanges.push(versions)
+  }
+}
+
+Suite.prototype._mapPackagesToVersions = function _mapPackagesToVersions(cb) {
+  const packages = Object.keys(this.pkgsMeta)
   const self = this
   a.mapLimit(
     packages,
@@ -71,9 +110,10 @@ Suite.prototype._mapPackagesToVersions = function _mapPackagesToVersions(package
         if (err) {
           return loadCb(err)
         }
-        versions = testUtil.maxVersionPerMode(Object.keys(versions), self.opts.versions)
+        const pkgMeta = self.pkgsMeta[pkg]
+        versions = testUtil.maxVersionPerMode(Object.keys(versions), self.opts.versions, pkgMeta)
         self.emit('packageResolved', pkg, versions)
-        loadCb(null, versions)
+        loadCb(null, { versions, latest: versions[versions.length - 1] })
       })
     },
     function loadHandler(err, versions) {
@@ -88,7 +128,7 @@ Suite.prototype._mapPackagesToVersions = function _mapPackagesToVersions(package
 
       // Now we have all of the package versions we'll need in an object looking
       // like this:
-      // {"package": ["1.2", "1.3", "2.0"]}
+      // {"package": { "versions": ["1.2", "1.3", "2.0"], "latest": "2.0"}}
       cb(null, pkgInfo)
     }
   )

--- a/tests/unit/versioned/matrix.tap.js
+++ b/tests/unit/versioned/matrix.tap.js
@@ -26,8 +26,8 @@ tap.test('TestMatrix construction', function (t) {
         }
       ],
       {
-        bluebird: ['1.0.8', '1.1.1', '1.2.4', '2.0.7'],
-        redis: ['1.2.3', '1.3.4', '2.0.1']
+        bluebird: { versions: ['1.0.8', '1.1.1', '1.2.4', '2.0.7'], latest: '2.0.7' },
+        redis: { versions: ['1.2.3', '1.3.4', '2.0.1'], latest: '2.0.1' }
       }
     )
   }, 'should construct without erroring')
@@ -56,9 +56,9 @@ tap.test(
         }
       ],
       {
-        'string-dep': ['0.0.0', '0.0.1', '0.0.2', '100.0.0'],
-        'test': ['1.0.0', '1.0.1', '1.0.2'],
-        'dep': ['0.0.1', '0.0.2', '0.0.3', '1.0.0', '1.0.1', '1.0.2']
+        'string-dep': { versions: ['0.0.0', '0.0.1', '0.0.2', '100.0.0'], latest: '100.0.0' },
+        'test': { versions: ['1.0.0', '1.0.1', '1.0.2'], latest: '1.0.2' },
+        'dep': { versions: ['0.0.1', '0.0.2', '0.0.3', '1.0.0', '1.0.1', '1.0.2'], latest: '1.0.2' }
       },
       2
     )
@@ -93,8 +93,8 @@ tap.test('TestMatrix methods and members', function (t) {
         }
       ],
       {
-        bluebird: ['1.0.8', '1.1.1', '1.2.4', '2.0.7'],
-        redis: ['1.2.3', '1.3.4', '2.0.1']
+        bluebird: { versions: ['1.0.8', '1.1.1', '1.2.4', '2.0.7'], latest: '2.0.7' },
+        redis: { versions: ['1.2.3', '1.3.4', '2.0.1'], latest: '2.0.1' }
       }
     )
   })
@@ -191,16 +191,16 @@ tap.test('Should return raw dependency version when does not directly match any 
   ]
 
   const retrievedPackageVersions = {
-    redis: ['1.2.3', '1.3.4', '2.0.1']
+    redis: { versions: ['1.2.3', '1.3.4', '2.0.1'], latest: '2.0.1' }
   }
 
   const matrix = new TestMatrix(tests, retrievedPackageVersions)
 
   const test1 = matrix.next()
-  t.equal(test1.packages.redis, 'latest')
+  t.equal(test1.packages.redis, '2.0.1')
 
   const test2 = matrix.next()
-  t.equal(test2.packages.redis, 'latest')
+  t.equal(test2.packages.redis, '2.0.1')
 
   const test3 = matrix.next()
   t.equal(test3.packages.redis, 'random')

--- a/tests/unit/versioned/test.tap.js
+++ b/tests/unit/versioned/test.tap.js
@@ -12,14 +12,15 @@ const fs = require('fs')
 const Test = require('../../../lib/versioned/test')
 
 const MOCK_TEST_DIR = path.resolve(__dirname, 'mock-tests')
+const pkgVersions = {
+  bluebird: { versions: ['1.0.8', '1.1.1', '1.2.4', '2.0.7'], latest: '2.0.7' },
+  redis: { versions: ['1.0.0', '2.0.1', '2.1.0'], latest: '2.1.0' }
+}
 
 tap.test('Test construction', function (t) {
   let test = null
   t.doesNotThrow(function () {
-    test = new Test(MOCK_TEST_DIR, {
-      bluebird: ['1.0.8', '1.1.1', '1.2.4', '2.0.7'],
-      redis: ['1.0.0', '2.0.1', '2.1.0']
-    })
+    test = new Test(MOCK_TEST_DIR, pkgVersions)
   }, 'should not throw when constructed')
 
   t.type(test, Test, 'should construct a Test instance')
@@ -31,10 +32,7 @@ tap.test('Test methods and members', function (t) {
 
   let test = null
   t.beforeEach(function () {
-    test = new Test(MOCK_TEST_DIR, {
-      bluebird: ['1.0.8', '1.1.1', '1.2.4', '2.0.7'],
-      redis: ['1.0.0', '2.0.1', '2.1.0']
-    })
+    test = new Test(MOCK_TEST_DIR, pkgVersions)
   })
 
   t.test('Test#peek', function (t) {
@@ -240,14 +238,7 @@ tap.test('Test methods and members', function (t) {
 })
 
 tap.test('Test run with allPkgs true', function (t) {
-  const test = new Test(
-    MOCK_TEST_DIR,
-    {
-      bluebird: ['1.0.8', '1.1.1', '1.2.4', '2.0.7'],
-      redis: ['1.0.0', '2.0.1', '2.1.0']
-    },
-    { allPkgs: true }
-  )
+  const test = new Test(MOCK_TEST_DIR, pkgVersions, { allPkgs: true })
 
   const testRun = test.run()
   testRun.on('end', function () {
@@ -328,48 +319,27 @@ tap.test('Test run with allPkgs true', function (t) {
 })
 
 tap.test('Will not filter tests when keywords are an empty list', function (t) {
-  const test = new Test(
-    MOCK_TEST_DIR,
-    {
-      bluebird: ['1.0.8', '1.1.1', '1.2.4', '2.0.7'],
-      redis: ['1.0.0', '2.0.1', '2.1.0']
-    },
-    {
-      testPatterns: []
-    }
-  )
+  const test = new Test(MOCK_TEST_DIR, pkgVersions, {
+    testPatterns: []
+  })
 
   t.equal(test.matrix._matrix[1].tests.files.length, 2, 'should include both test files')
   t.end()
 })
 
 tap.test('should filter based on multiple keywords', function (t) {
-  const test = new Test(
-    MOCK_TEST_DIR,
-    {
-      bluebird: ['1.0.8', '1.1.1', '1.2.4', '2.0.7'],
-      redis: ['1.0.0', '2.0.1', '2.1.0']
-    },
-    {
-      testPatterns: ['other.mock.tap.js', 'redis']
-    }
-  )
+  const test = new Test(MOCK_TEST_DIR, pkgVersions, {
+    testPatterns: ['other.mock.tap.js', 'redis']
+  })
 
   t.equal(test.matrix._matrix[1].tests.files.length, 2, 'should include both test files')
   t.end()
 })
 
 tap.test('Can filter tests by keyword', function (t) {
-  const test = new Test(
-    MOCK_TEST_DIR,
-    {
-      bluebird: ['1.0.8', '1.1.1', '1.2.4', '2.0.7'],
-      redis: ['1.0.0', '2.0.1', '2.1.0']
-    },
-    {
-      testPatterns: ['redis']
-    }
-  )
+  const test = new Test(MOCK_TEST_DIR, pkgVersions, {
+    testPatterns: ['redis']
+  })
 
   t.equal(test.matrix._matrix[1].tests.files.length, 1, 'should include only one test file')
   t.equal(
@@ -381,16 +351,9 @@ tap.test('Can filter tests by keyword', function (t) {
 })
 
 tap.test('should filter tests completely out when 0 matches based on patterns', function (t) {
-  const test = new Test(
-    MOCK_TEST_DIR,
-    {
-      bluebird: ['1.0.8'],
-      redis: ['1.0.0']
-    },
-    {
-      testPatterns: ['no-match']
-    }
-  )
+  const test = new Test(MOCK_TEST_DIR, pkgVersions, {
+    testPatterns: ['no-match']
+  })
 
   t.equal(test.matrix._matrix.length, 0, 'should completely filter out matrix')
   t.end()
@@ -409,10 +372,7 @@ tap.test('check for unspecified test files', function (t) {
   })
 
   t.test('alert when files are not included in the test specification', function (t) {
-    const test = new Test(MOCK_TEST_DIR, {
-      bluebird: ['1.0.8'],
-      redis: ['1.0.0']
-    })
+    const test = new Test(MOCK_TEST_DIR, pkgVersions)
     t.equal(test.missingFiles.length, 1)
     t.end()
   })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Fixed how version resolution occurs when semver ranges are not the latest major version.
 * Fixed how `latest` gets resolved by actually using the latest version.

## Links
Closes #116

## Details

Previously you'd see in this version list things like `latest` or a semver range like `mysql2(1): >=1.3.1 <1.6.2`

```sh
===============================================================
Versions executed

Folder: apollo-federation
	 * @apollo/federation(1): 0.35.3
	 * @apollo/gateway(1): 0.48.3
	 * @opentelemetry/api(1): 0.21.0
	 * apollo-server(1): 2.25.3
	 * graphql(1): 14.7.0
Folder: apollo-server-express
	 * apollo-server-express(2): 2.25.3, 3.6.4
	 * express(1): 4.17.1
	 * graphql(1): 15.8.0
Folder: apollo-server-fastify
	 * apollo-server-fastify(2): 2.25.3, 3.6.4
	 * fastify(1): 3.17.0
	 * graphql(1): 15.8.0
Folder: apollo-server-hapi
	 * apollo-server-hapi(1): 3.6.4
	 * @hapi/hapi(1): 20.2.1
Folder: apollo-server-koa
	 * apollo-server-koa(2): 2.25.3, 3.6.4
	 * koa(1): 2.13.4
	 * graphql(1): 15.8.0
Folder: apollo-server-lambda
	 * apollo-server-lambda(2): 2.25.3, 3.6.4
	 * graphql(1): 15.8.0
Folder: apollo-server
	 * apollo-server(2): 3.6.4, 2.25.3
	 * graphql(1): 15.8.0
Folder: v2
	 * aws-sdk(2): 2.2.48, 2.1093.0
	 * amazon-dax-client(1): 1.2.7
Folder: v3
	 * @aws-sdk/client-api-gateway(1): 3.54.0
	 * @aws-sdk/client-elasticache(1): 3.54.0
	 * @aws-sdk/client-elastic-load-balancing(1): 3.54.0
	 * @aws-sdk/client-lambda(1): 3.54.0
	 * @aws-sdk/client-rds(1): 3.54.0
	 * @aws-sdk/client-redshift(1): 3.54.0
	 * @aws-sdk/client-rekognition(1): 3.54.0
	 * @aws-sdk/client-s3(1): 3.54.0
	 * @aws-sdk/client-ses(1): 3.54.0
	 * @aws-sdk/client-sns(1): 3.54.0
	 * @aws-sdk/client-sqs(1): 3.54.0
	 * @aws-sdk/client-dynamodb(1): 3.54.0
	 * @aws-sdk/util-dynamodb(1): 3.54.0
	 * @aws-sdk/lib-dynamodb(1): 3.54.0
Folder: koa-tests
	 * koa(2): 1.7.0, 2.13.4
	 * @koa/router(1): 8.0.2
	 * koa-router(1): 7.4.0
	 * koa-route(1): 3.2.0
Folder: nextjs-tests
	 * next(1): 12.1.0
	 * react(1): 17.0.2
	 * react-dom(1): 17.0.2
Folder: superagent-tests
	 * superagent(6): 2.3.0, 3.8.3, 4.1.0, 5.3.1, 6.1.0, 7.1.1
Folder: amqplib
	 * amqplib(1): 0.8.0
Folder: bluebird
	 * bluebird(2): 2.11.0, 3.7.2
Folder: cassandra-driver
	 * cassandra-driver(2): 3.6.0, 4.6.3
Folder: cls
	 * continuation-local-storage(1): 3.2.1
	 * async-listener(1): 0.6.10
Folder: connect
	 * connect(3): 1.9.2, 2.30.2, 3.7.0
Folder: director(SKIPPED)
Folder: express
	 * express(2): 4.17.1, 4.17.3
	 * express-enrouten(1): 1.1
	 * ejs(1): 2.5.5
Folder: fastify
	 * fastify(3): 2.15.3, 3.17.0, 3.27.4
	 * middie(1): 5.3.0
Folder: generic-pool
	 * generic-pool(2): 3.8.2, 2.5.4
Folder: hapi-17(SKIPPED)
Folder: hapi-post-18
	 * ejs(1): 2.5.5
	 * @hapi/hapi(1): 20.2.1
	 * vision(1): 5.4.4
Folder: hapi-pre-17(SKIPPED)
Folder: ioredis
	 * ioredis(2): 3.2.2, 4.28.5
Folder: mongodb
	 * mongodb(3): 2.2.36, 3.7.3, 4.4.1
Folder: mysql
	 * mysql(1): 2.18.1
	 * generic-pool(1): 2.4
Folder: mysql2
	 * mysql2(2): 1.7.0, 2.3.3
	 * generic-pool(1): 2.4 <2.5
Folder: pg-post-7
	 * pg(1): 8.7.3
	 * pg-native(1): 2.2.0
Folder: pg-pre-7(SKIPPED)
Folder: redis
	 * redis(2): 2.8.0, 3.1.2
Folder: restify-post-7
	 * restify(2): 7.7.0, 8.6.1
	 * express(1): 4.16
	 * restify-errors(1): 6.1.1
Folder: restify-pre-7
	 * restify(2): 5.2.1, 6.4.0
	 * express(1): 4.16
	 * restify-errors(1): 6.1.1
Folder: undici
	 * undici(1): 4.15.1
===============================================================
```

To test this:

`npm link`

Go to agent and run

```sh
npm link @newrelic/test-utilities
npm run versioned:major
```
