### PR TITLE
sort versions when finding max version by semver range

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -145,6 +145,7 @@ util.maxVersionPerMode = function maxVersionPerMode(versions, mode, meta) {
   versions = versions.filter((version) => {
     return /^\d+\.\d+\.\d+$/.test(version)
   })
+  versions = sortFloats(versions)
 
   if (mode === 'patch') {
     return versions
@@ -181,5 +182,15 @@ util.maxVersionPerMode = function maxVersionPerMode(versions, mode, meta) {
     }
   })
 
-  return greatestVersions
+  return sortFloats(greatestVersions)
+}
+
+/**
+ * Sort float numbers ascending.  This is being used to ensure proper order of
+ * package versions so the last element in array is always the `latest`
+ *
+ * @param {Array} floatNumbers array of float number strings
+ */
+function sortFloats(floatNumbers) {
+  return floatNumbers.sort((a, b) => parseFloat(a) - parseFloat(b))
 }

--- a/tests/unit/util.tap.js
+++ b/tests/unit/util.tap.js
@@ -140,5 +140,32 @@ tap.test('testUtil.maxVersionPerMode', (t) => {
     t.end()
   })
 
+  t.test('should sort versions properly', (t) => {
+    const meta = { semverRanges: [], staticVersions: [], latest: true }
+    const versions = ['14.0.0', '14.0.3', '2.0.0', '0.10.0', '10.0.0', '15.0.0', '2.1.0', '2.0.1']
+
+    const majorResult = testUtil.maxVersionPerMode(versions, 'major', meta)
+    t.same(
+      majorResult,
+      ['0.10.0', '2.1.0', '10.0.0', '14.0.3', '15.0.0'],
+      'should sort major properly'
+    )
+
+    const minorResult = testUtil.maxVersionPerMode(versions, 'minor', meta)
+    t.same(
+      minorResult,
+      ['0.10.0', '2.0.1', '2.1.0', '10.0.0', '14.0.3', '15.0.0'],
+      'should sort minor properly'
+    )
+
+    const patchResult = testUtil.maxVersionPerMode(versions, 'patch', meta)
+    t.same(
+      patchResult,
+      ['0.10.0', '2.0.0', '2.0.1', '2.1.0', '10.0.0', '14.0.0', '14.0.3', '15.0.0'],
+      'should sort patch properly'
+    )
+    t.end()
+  })
+
   t.end()
 })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Sort package versions properly when returning max version by every semver range.

## Links

## Details
This was causing issues in apollo-server versioned tests and I realized the last element in the version array was not always the "latest".  This PR will sort float strings ascending to ensure the last element is latest.
