### PR TITLE
Bumps async to ^3.2.3.

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -45,7 +45,7 @@ code, the source code can be found at [https://github.com/newrelic/node-test-uti
 
 ### async
 
-This product includes source derived from [async](https://github.com/caolan/async) ([v2.6.3](https://github.com/caolan/async/tree/v2.6.3)), distributed under the [MIT License](https://github.com/caolan/async/blob/v2.6.3/LICENSE):
+This product includes source derived from [async](https://github.com/caolan/async) ([v3.2.3](https://github.com/caolan/async/tree/v3.2.3)), distributed under the [MIT License](https://github.com/caolan/async/blob/v3.2.3/LICENSE):
 
 ```
 Copyright (c) 2010-2018 Caolan McMahon

--- a/lib/versioned/suite.js
+++ b/lib/versioned/suite.js
@@ -195,7 +195,7 @@ Suite.prototype._runTests = function _runTests(pkgVersions, cb) {
     queue.push(test)
   })
 
-  queue.drain = cb
+  queue.drain(cb)
 }
 
 module.exports = Suite

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "6.5.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "async": "^2.6.0",
+        "async": "^3.2.3",
         "colors": "^1.1.2",
         "commander": "^2.14.1",
         "concat-stream": "^1.6.0",
@@ -2898,12 +2898,9 @@
       }
     },
     "node_modules/async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-      "dependencies": {
-        "lodash": "^4.17.14"
-      }
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
     },
     "node_modules/async-hook-domain": {
       "version": "2.0.4",
@@ -6359,12 +6356,6 @@
       "optionalDependencies": {
         "@newrelic/native-metrics": "^7.0.1"
       }
-    },
-    "node_modules/newrelic/node_modules/async": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
-      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
-      "dev": true
     },
     "node_modules/newrelic/node_modules/concat-stream": {
       "version": "2.0.0",
@@ -12681,12 +12672,9 @@
       "dev": true
     },
     "async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-      "requires": {
-        "lodash": "^4.17.14"
-      }
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
     },
     "async-hook-domain": {
       "version": "2.0.4",
@@ -15335,12 +15323,6 @@
         "semver": "^5.3.0"
       },
       "dependencies": {
-        "async": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
-          "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
-          "dev": true
-        },
         "concat-stream": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "tap": "^16.0.1"
   },
   "dependencies": {
-    "async": "^2.6.0",
+    "async": "^3.2.3",
     "colors": "^1.1.2",
     "commander": "^2.14.1",
     "concat-stream": "^1.6.0",

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,19 +1,19 @@
 {
-  "lastUpdated": "Thu Mar 24 2022 09:33:47 GMT-0700 (Pacific Daylight Time)",
+  "lastUpdated": "Mon Apr 18 2022 13:14:43 GMT-0700 (Pacific Daylight Time)",
   "projectName": "New Relic Test Utilities",
   "projectUrl": "https://github.com/newrelic/node-test-utilities",
   "includeOptDeps": false,
   "includeDev": true,
   "dependencies": {
-    "async@2.6.3": {
+    "async@3.2.3": {
       "name": "async",
-      "version": "2.6.3",
-      "range": "^2.6.0",
+      "version": "3.2.3",
+      "range": "^3.2.3",
       "licenses": "MIT",
       "repoUrl": "https://github.com/caolan/async",
-      "versionedRepoUrl": "https://github.com/caolan/async/tree/v2.6.3",
+      "versionedRepoUrl": "https://github.com/caolan/async/tree/v3.2.3",
       "licenseFile": "node_modules/async/LICENSE",
-      "licenseUrl": "https://github.com/caolan/async/blob/v2.6.3/LICENSE",
+      "licenseUrl": "https://github.com/caolan/async/blob/v3.2.3/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Caolan McMahon"
     },


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Bumped async to ^3.2.3.

  Updated usage of `queue.drain` which was a 3.x breaking change.

## Links

## Details

There's some concurrent functionality of async used in suite.js that would make removing async take a bit longer than ideal, so upgrading for now.

https://github.com/caolan/async/blob/master/CHANGELOG.md#v300