### PR TITLE
Remove cleaning npm cache on package install failure

### DIFF
--- a/lib/versioned/runner.js
+++ b/lib/versioned/runner.js
@@ -14,7 +14,6 @@ const cp = require('child_process')
 // -) Exit codes less than zero mean this script failed.
 // 0) Exit codes equal to zero mean everything worked.
 
-const INSTALL_ATTEMPT_LIMIT = 3
 const CHILD_TIMEOUT = 60 * 1000 // 1 minute
 const CHILD_KILL_TIMEOUT = 10 * 1000 // 10 seconds
 
@@ -72,9 +71,9 @@ function installPackages(cb) {
     return cb()
   }
 
-  tryInstall(0)
+  tryInstall()
 
-  function tryInstall(attempts) {
+  function tryInstall() {
     let args = [
       'install',
       '--no-save', // do not update package file
@@ -85,26 +84,9 @@ function installPackages(cb) {
     args = args.concat(packages)
     spawn('npm', args, function installHandler(err) {
       if (err) {
-        if (++attempts < INSTALL_ATTEMPT_LIMIT) {
-          console.error('Clearing cache and retrying failed install...')
-          setTimeout(function installRetry() {
-            spawn('npm', ['cache', 'clean'], function cacheHandler(e) {
-              if (e) {
-                const error = new Error('Failed to clear cache: ' + e.stack)
-                error.code = -Math.abs(e.code || 0xbeef)
-                return cb(error)
-              }
-              tryInstall(attempts)
-            })
-          }, 5000 * attempts) // 5 seconds * number of attempts
-          return
-        }
-
-        const error = new Error('Failed to install packages: ' + err.stack)
-        error.code = -Math.abs(err.code)
-        return cb(error)
+        err.code = -Math.abs(err.code)
       }
-      cb()
+      cb(err)
     })
   }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Updated version runner to fail if package fails to install and not attempt to clean the npm cache.

## Links
Closes #129

## Details
I didn't update any tests because we don't explicitly test the runner as it is very hard.  To test I did the following

```
npm link
```

In agent
```
npm link @newrelic/test-utilities
npm run versioned
```
