### PR TITLE
add TEST_CHILD_TIMEOUT for modifying test timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,14 @@ different files for each version of `mongodb` from `v1.0.0` through to the lates
 }
 ```
 
+The versioned tests runner has a timeout for tests that defaults to one minute. That is, if running a test -- including installing its dependencies! -- takes longer than a minute, then that test is considered to have failed. You can change this timeout with the `TEST_CHILD_TIMEOUT` environment variable, which is interpreted as a number of milliseconds. For example, to set a test timeout of ten minutes, you could invoke the test runner like this:
+
+```sh
+$ TEST_CHILD_TIMEOUT=600000 versioned-tests
+```
+
+As ten minutes is 600,000 milliseconds.
+
 ## Testing
 The module includes a suite of unit and functional tests which should be used to
 verify that your changes don't break existing functionality.

--- a/lib/versioned/runner.js
+++ b/lib/versioned/runner.js
@@ -14,7 +14,10 @@ const cp = require('child_process')
 // -) Exit codes less than zero mean this script failed.
 // 0) Exit codes equal to zero mean everything worked.
 
-const CHILD_TIMEOUT = 60 * 1000 // 1 minute
+const CHILD_TIMEOUT_DEFAULT = 60 * 1000 // 1 minute
+const CHILD_TIMEOUT = process.env.TEST_CHILD_TIMEOUT
+  ? parseInt(process.env.TEST_CHILD_TIMEOUT, 10)
+  : CHILD_TIMEOUT_DEFAULT
 const CHILD_KILL_TIMEOUT = 10 * 1000 // 10 seconds
 
 const packages = process.argv.slice(2)


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Add TEST_CHILD_TIMEOUT environment variable to modify test timeout limits.

## Links

* Closes https://github.com/newrelic/node-test-utilities/issues/132

## Details

Includes no tests, only a readme update, because nothing tests the runner apparently. I've tested it manually and it works fine.