### PR TITLE
Streamlined CLM assertion tests, bypassing old abstractions

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1047,7 +1047,7 @@ SOFTWARE.
 
 ### newrelic
 
-This product includes source derived from [newrelic](https://github.com/newrelic/node-newrelic) ([v9.7.2](https://github.com/newrelic/node-newrelic/tree/v9.7.2)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-newrelic/blob/v9.7.2/LICENSE):
+This product includes source derived from [newrelic](https://github.com/newrelic/node-newrelic) ([v9.7.3](https://github.com/newrelic/node-newrelic/tree/v9.7.3)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-newrelic/blob/v9.7.3/LICENSE):
 
 ```
                                  Apache License

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -415,6 +415,8 @@ function _assertCLMAttrs({ segments, enabled: clmEnabled }) {
   segments.forEach((segment) => {
     const attrs = segment.segment.getAttributes()
     if (clmEnabled) {
+      this.ok(attrs['code.function'], 'CLM segments should have code.function')
+      this.ok(attrs['code.filepath'], 'CLM segments should have code.filepath')
       this.equal(attrs['code.function'], segment.name, 'should have appropriate code.function')
       this.ok(
         attrs['code.filepath'].endsWith(segment.filepath),

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -25,7 +25,7 @@ const assert = module.exports
 assert.extendTap = function extendTap(tap) {
   const addAssert = tap.Test.prototype.addAssert.bind(tap.Test.prototype)
   addAssert('transaction', 1, _tapper1(_transactionTest))
-  addAssert('clmAttrs', 1, _tapper1(_assertCLMAttrs))
+  addAssert('clmAttrs', 1, _assertCLMAttrs)
 
   addAssert('metrics', 1, _tapper1(_metricsTest))
   addAssert('exactMetrics', 1, _tapper1(_exactMetricsTest))
@@ -410,38 +410,23 @@ function _tapper2(test) {
  * @param {object} params
  * @param {object} params.segments list of segments to assert { segment, filepath, name }
  * @param {boolean} params.enabled if CLM is enabled or not
- * @param {object} params.test tap test context, to allow the use of tap assertions here
  */
-function _assertCLMAttrs({ segments, enabled: clmEnabled, test }) {
+function _assertCLMAttrs({ segments, enabled: clmEnabled }) {
   segments.forEach((segment) => {
     const attrs = segment.segment.getAttributes()
     if (clmEnabled) {
-      test.ok(attrs['code.function'], 'should have code.function')
-      test.equal(
-        attrs['code.function'],
-        segment.name,
-        'code.function value should match segment.name'
-      )
-      test.ok(
+      this.equal(attrs['code.function'], segment.name, 'should have appropriate code.function')
+      this.ok(
         attrs['code.filepath'].endsWith(segment.filepath),
-        `code.filepath (${attrs['code.filepath']}) should end with ${segment.filepath}`
+        'should have appropriate code.filepath'
       )
-      test.match(attrs['code.lineno'], /[\d]+/, 'lineno should be a number')
-      test.match(attrs['code.column'], /[\d]+/, 'column should be a number')
-      return {
-        success: true,
-        message: `CLM behaves as expected when active`
-      }
-    }
-    test.notOk(attrs['code.function'], 'code.function should not exist')
-    test.notOk(attrs['code.filepath'], 'code.filepath should not exist')
-    test.notOk(attrs['code.lineno'], 'code.lineno should not exist')
-    test.notOk(attrs['code.column'], 'code.column should not exist')
-    return {
-      success: true,
-      message: `CLM should noop when inactive`
+      this.match(attrs['code.lineno'], /[\d]+/, 'lineno should be a number')
+      this.match(attrs['code.column'], /[\d]+/, 'column should be a number')
+    } else {
+      this.notOk(attrs['code.function'], 'function should not exist')
+      this.notOk(attrs['code.filepath'], 'filepath should not exist')
+      this.notOk(attrs['code.lineno'], 'lineno should not exist')
+      this.notOk(attrs['code.column'], 'column should not exist')
     }
   })
-  return { success: true, message: 'CLM behaves as expected' }
 }
-assert.clmAttrs = _asserter1(_assertCLMAttrs)

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -432,3 +432,5 @@ function _assertCLMAttrs({ segments, enabled: clmEnabled }) {
     }
   })
 }
+
+assert.clmAttrs = _assertCLMAttrs

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "husky": "^6.0.0",
         "jsdoc": "^3.5.5",
         "lint-staged": "^11.0.0",
-        "newrelic": "^9.7.2",
+        "newrelic": "^9.7.3",
         "prettier": "^2.3.2",
         "sinon": "^11.1.1",
         "tap": "^16.0.1"
@@ -6664,9 +6664,9 @@
       }
     },
     "node_modules/newrelic": {
-      "version": "9.7.2",
-      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-9.7.2.tgz",
-      "integrity": "sha512-SzjngZYv4VNQpseBN1KkHoEOKo5dl0Hrtbs1uKi+kIO0899vh2u7fLKJuLtp6jBSgwTMp71dO6G2/cclbUXz7w==",
+      "version": "9.7.3",
+      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-9.7.3.tgz",
+      "integrity": "sha512-C9xXvFW5WKckQI4HgGuywkoqw9DkL5nBqkfd2ncnQFsvIVstcn7ozUD9br0xEKVCkgDMzAC92evDTK3nk/m3tA==",
       "dev": true,
       "dependencies": {
         "@grpc/grpc-js": "^1.7.3",
@@ -15979,9 +15979,9 @@
       "dev": true
     },
     "newrelic": {
-      "version": "9.7.2",
-      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-9.7.2.tgz",
-      "integrity": "sha512-SzjngZYv4VNQpseBN1KkHoEOKo5dl0Hrtbs1uKi+kIO0899vh2u7fLKJuLtp6jBSgwTMp71dO6G2/cclbUXz7w==",
+      "version": "9.7.3",
+      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-9.7.3.tgz",
+      "integrity": "sha512-C9xXvFW5WKckQI4HgGuywkoqw9DkL5nBqkfd2ncnQFsvIVstcn7ozUD9br0xEKVCkgDMzAC92evDTK3nk/m3tA==",
       "dev": true,
       "requires": {
         "@contrast/fn-inspect": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "husky": "^6.0.0",
     "jsdoc": "^3.5.5",
     "lint-staged": "^11.0.0",
-    "newrelic": "^9.7.2",
+    "newrelic": "^9.7.3",
     "prettier": "^2.3.2",
     "sinon": "^11.1.1",
     "tap": "^16.0.1"

--- a/tests/unit/assert.tap.js
+++ b/tests/unit/assert.tap.js
@@ -330,7 +330,7 @@ tap.test('assert.exactSegments', function (t) {
 })
 ;[true, false].forEach((enabled) => {
   config = { code_level_metrics: { enabled } }
-  tap.test(enabled ? 'should add attributes' : 'should not add attributes', function (t) {
+  tap.test(enabled ? 'should add CLM attributes' : 'should not add attributes', function (t) {
     const symbols = testUtils.symbols
     const addCLMAttributes = testUtils.clmUtils
     const tx = helper.runInTransaction(function createTransaction(tx) {
@@ -363,8 +363,7 @@ tap.test('assert.exactSegments', function (t) {
           filepath
         }
       ],
-      enabled,
-      test: t // passing this for more readable assertions
+      enabled
     })
     t.end()
   })

--- a/tests/unit/assert.tap.js
+++ b/tests/unit/assert.tap.js
@@ -332,7 +332,7 @@ tap.test('assert.exactSegments', function (t) {
   config = { code_level_metrics: { enabled } }
   tap.test(enabled ? 'should add CLM attributes' : 'should not add attributes', function (t) {
     const symbols = testUtils.symbols
-    const addCLMAttributes = testUtils.clmUtils
+    const { addCLMAttributes } = testUtils.clmUtils
     const tx = helper.runInTransaction(function createTransaction(tx) {
       return tx
     })

--- a/tests/unit/assert.tap.js
+++ b/tests/unit/assert.tap.js
@@ -330,7 +330,7 @@ tap.test('assert.exactSegments', function (t) {
 })
 ;[true, false].forEach((enabled) => {
   config = { code_level_metrics: { enabled } }
-  tap.test(enabled ? 'should add CLM attributes' : 'should not add attributes', function (t) {
+  tap.test(enabled ? 'should add CLM attributes' : 'should not add CLM attributes', function (t) {
     const symbols = testUtils.symbols
     const { addCLMAttributes } = testUtils.clmUtils
     const tx = helper.runInTransaction(function createTransaction(tx) {

--- a/tests/unit/util.tap.js
+++ b/tests/unit/util.tap.js
@@ -191,3 +191,9 @@ tap.test('testUtil.maxVersionPerMode', (t) => {
 
   t.end()
 })
+
+tap.test('new helpers are available', (t) => {
+  t.type(testUtil.clmUtils, 'function', 'util should export clmUtils as an object')
+  t.type(testUtil.symbols, 'object', 'util should export symbols as an object')
+  t.end()
+})

--- a/tests/unit/util.tap.js
+++ b/tests/unit/util.tap.js
@@ -193,7 +193,17 @@ tap.test('testUtil.maxVersionPerMode', (t) => {
 })
 
 tap.test('new helpers are available', (t) => {
-  t.type(testUtil.clmUtils, 'function', 'util should export clmUtils as an object')
+  t.type(testUtil.clmUtils, 'object', 'util should export clmUtils as an object')
+  t.type(
+    testUtil.clmUtils.assignCLMSymbol,
+    'function',
+    'clmUtils should expose an assignCLMSymbol function'
+  )
+  t.type(
+    testUtil.clmUtils.addCLMAttributes,
+    'function',
+    'clmUtils should expose an addCLMAttributes function'
+  )
   t.type(testUtil.symbols, 'object', 'util should export symbols as an object')
   t.end()
 })

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Thu Dec 08 2022 17:32:56 GMT-0500 (Eastern Standard Time)",
+  "lastUpdated": "Wed Dec 14 2022 13:44:13 GMT-0500 (Eastern Standard Time)",
   "projectName": "New Relic Test Utilities",
   "projectUrl": "https://github.com/newrelic/node-test-utilities",
   "includeOptDeps": false,
@@ -247,15 +247,15 @@
       "publisher": "Andrey Okonetchnikov",
       "email": "andrey@okonet.ru"
     },
-    "newrelic@9.7.2": {
+    "newrelic@9.7.3": {
       "name": "newrelic",
-      "version": "9.7.2",
-      "range": "^9.7.2",
+      "version": "9.7.3",
+      "range": "^9.7.3",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/newrelic/node-newrelic",
-      "versionedRepoUrl": "https://github.com/newrelic/node-newrelic/tree/v9.7.2",
+      "versionedRepoUrl": "https://github.com/newrelic/node-newrelic/tree/v9.7.3",
       "licenseFile": "node_modules/newrelic/LICENSE",
-      "licenseUrl": "https://github.com/newrelic/node-newrelic/blob/v9.7.2/LICENSE",
+      "licenseUrl": "https://github.com/newrelic/node-newrelic/blob/v9.7.3/LICENSE",
       "licenseTextSource": "file",
       "publisher": "New Relic Node.js agent team",
       "email": "nodejs@newrelic.com"


### PR DESCRIPTION
Signed-off-by: mrickard <maurice@mauricerickard.com>

## Proposed Release Notes

Streamlined CLM assertions to inherit tap from context. 
Bypassed tapper/asserter abstractions so that CLM test failures are exposed.

## Links

https://issues.newrelic.com/browse/NEWRELIC-5779

## Details
