### PR TITLE
Update tap to use the latest json5

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -7442,7 +7442,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ### tap
 
-This product includes source derived from [tap](https://github.com/tapjs/node-tap) ([v16.3.2](https://github.com/tapjs/node-tap/tree/v16.3.2)), distributed under the [ISC License](https://github.com/tapjs/node-tap/blob/v16.3.2/LICENSE):
+This product includes source derived from [tap](https://github.com/tapjs/node-tap) ([v16.3.3](https://github.com/tapjs/node-tap/tree/v16.3.3)), distributed under the [ISC License](https://github.com/tapjs/node-tap/blob/v16.3.3/LICENSE):
 
 ```
 The ISC License

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "newrelic": "^9.7.3",
         "prettier": "^2.3.2",
         "sinon": "^11.1.1",
-        "tap": "^16.0.1"
+        "tap": "^16.3.3"
       },
       "engines": {
         "node": ">=14.0"
@@ -7971,9 +7971,9 @@
       "dev": true
     },
     "node_modules/tap": {
-      "version": "16.3.2",
-      "resolved": "https://registry.npmjs.org/tap/-/tap-16.3.2.tgz",
-      "integrity": "sha512-4MWMObR8unbv5gAHHVW9F0MNk3opQMnLusSWvt4KBAnKmkwpBRKIfNF64fimQbcR4y9a7U9ISV7pCldlV3J8Pw==",
+      "version": "16.3.3",
+      "resolved": "https://registry.npmjs.org/tap/-/tap-16.3.3.tgz",
+      "integrity": "sha512-E6Ti4FaH3zUvOtl13GA60n8aodRj44S8Vu5efM84U5NmquJo4+y21+2VM9r9jR5iiEcce5dqvlrrwAhZ6r11xg==",
       "bundleDependencies": [
         "ink",
         "treport",
@@ -9234,7 +9234,7 @@
       }
     },
     "node_modules/tap/node_modules/json5": {
-      "version": "2.2.1",
+      "version": "2.2.3",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -16626,9 +16626,9 @@
       "dev": true
     },
     "tap": {
-      "version": "16.3.2",
-      "resolved": "https://registry.npmjs.org/tap/-/tap-16.3.2.tgz",
-      "integrity": "sha512-4MWMObR8unbv5gAHHVW9F0MNk3opQMnLusSWvt4KBAnKmkwpBRKIfNF64fimQbcR4y9a7U9ISV7pCldlV3J8Pw==",
+      "version": "16.3.3",
+      "resolved": "https://registry.npmjs.org/tap/-/tap-16.3.3.tgz",
+      "integrity": "sha512-E6Ti4FaH3zUvOtl13GA60n8aodRj44S8Vu5efM84U5NmquJo4+y21+2VM9r9jR5iiEcce5dqvlrrwAhZ6r11xg==",
       "dev": true,
       "requires": {
         "@isaacs/import-jsx": "^4.0.1",
@@ -17394,7 +17394,7 @@
           "dev": true
         },
         "json5": {
-          "version": "2.2.1",
+          "version": "2.2.3",
           "bundled": true,
           "dev": true
         },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "newrelic": "^9.7.3",
     "prettier": "^2.3.2",
     "sinon": "^11.1.1",
-    "tap": "^16.0.1"
+    "tap": "^16.3.3"
   },
   "dependencies": {
     "async": "^3.2.3",

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Tue Dec 20 2022 09:53:07 GMT-0500 (Eastern Standard Time)",
+  "lastUpdated": "Mon Jan 09 2023 10:38:40 GMT-0500 (GMT-05:00)",
   "projectName": "New Relic Test Utilities",
   "projectUrl": "https://github.com/newrelic/node-test-utilities",
   "includeOptDeps": false,
@@ -298,15 +298,15 @@
       "licenseTextSource": "file",
       "publisher": "Christian Johansen"
     },
-    "tap@16.3.2": {
+    "tap@16.3.3": {
       "name": "tap",
-      "version": "16.3.2",
-      "range": "^16.0.1",
+      "version": "16.3.3",
+      "range": "^16.3.3",
       "licenses": "ISC",
       "repoUrl": "https://github.com/tapjs/node-tap",
-      "versionedRepoUrl": "https://github.com/tapjs/node-tap/tree/v16.3.2",
+      "versionedRepoUrl": "https://github.com/tapjs/node-tap/tree/v16.3.3",
       "licenseFile": "node_modules/tap/LICENSE",
-      "licenseUrl": "https://github.com/tapjs/node-tap/blob/v16.3.2/LICENSE",
+      "licenseUrl": "https://github.com/tapjs/node-tap/blob/v16.3.3/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Isaac Z. Schlueter",
       "email": "i@izs.me",


### PR DESCRIPTION
This complements https://github.com/newrelic/node-test-utilities/pull/157 to also update a dep for tap.