### PR TITLE
chore: updated fake agent to register ritm hooks

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1277,7 +1277,7 @@ This product includes source derived from [lockfile-lint](https://github.com/lir
 
 ### newrelic
 
-This product includes source derived from [newrelic](https://github.com/newrelic/node-newrelic) ([v10.6.2](https://github.com/newrelic/node-newrelic/tree/v10.6.2)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-newrelic/blob/v10.6.2/LICENSE):
+This product includes source derived from [newrelic](https://github.com/newrelic/node-newrelic) ([v11.0.0](https://github.com/newrelic/node-newrelic/tree/v11.0.0)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-newrelic/blob/v11.0.0/LICENSE):
 
 ```
                                  Apache License

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -134,12 +134,12 @@ TestAgent.makeFullyInstrumented = function makeInstrumented(conf, setState) {
  */
 TestAgent.prototype.instrument = function instrument(instrumentFull = false) {
   shimmer.debug = true
-  shimmer.patchModule(this.agent)
   if (instrumentFull) {
     shimmer.bootstrapInstrumentation(this.agent)
   } else {
     shimmer.registerCoreInstrumentation(this.agent)
   }
+  shimmer.registerHooks(this.agent)
 
   return this
 }
@@ -153,7 +153,7 @@ TestAgent.prototype.instrument = function instrument(instrumentFull = false) {
  * that tests aren't stepping on eachothers' toes.
  */
 TestAgent.prototype.unload = function unload() {
-  shimmer.unpatchModule()
+  shimmer.removeHooks()
   shimmer.unwrapAll()
   shimmer.debug = false
   shimmer.registeredInstrumentations = Object.create(null)

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "koa": "^2.14.2",
         "lint-staged": "^11.0.0",
         "lockfile-lint": "^4.9.6",
-        "newrelic": "^10.3.0",
+        "newrelic": "^11.0.0",
         "prettier": "^2.3.2",
         "sinon": "^11.1.1",
         "tap": "^16.3.8"
@@ -1002,39 +1002,6 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
-    "node_modules/@chevrotain/cst-dts-gen": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-10.5.0.tgz",
-      "integrity": "sha512-lhmC/FyqQ2o7pGK4Om+hzuDrm9rhFYIJ/AXoQBeongmn870Xeb0L6oGEiuR8nohFNL5sMaQEJWCxr1oIVIVXrw==",
-      "dev": true,
-      "dependencies": {
-        "@chevrotain/gast": "10.5.0",
-        "@chevrotain/types": "10.5.0",
-        "lodash": "4.17.21"
-      }
-    },
-    "node_modules/@chevrotain/gast": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-10.5.0.tgz",
-      "integrity": "sha512-pXdMJ9XeDAbgOWKuD1Fldz4ieCs6+nLNmyVhe2gZVqoO7v8HXuHYs5OV2EzUtbuai37TlOAQHrTDvxMnvMJz3A==",
-      "dev": true,
-      "dependencies": {
-        "@chevrotain/types": "10.5.0",
-        "lodash": "4.17.21"
-      }
-    },
-    "node_modules/@chevrotain/types": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-10.5.0.tgz",
-      "integrity": "sha512-f1MAia0x/pAVPWH/T73BJVyO2XU5tI4/iE7cnxb7tqdNTNhQI3Uq3XkqcoteTmD4t1aM0LbHCJOhgIDn07kl2A==",
-      "dev": true
-    },
-    "node_modules/@chevrotain/utils": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-10.5.0.tgz",
-      "integrity": "sha512-hBzuU5+JjB2cqNZyszkDHZgOSrUUT8V3dhgRl8Q9Gp6dAj/H5+KILGjbhDpc3Iy9qmqlm/akuOI2ut9VUtzJxQ==",
-      "dev": true
-    },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -1343,28 +1310,16 @@
         "node": ">=v12.0.0"
       }
     },
-    "node_modules/@mrleebo/prisma-ast": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@mrleebo/prisma-ast/-/prisma-ast-0.5.2.tgz",
-      "integrity": "sha512-v2jwtrLt/x5/MaF7Sucsz/do8tDUmiq3KA+UYdyZfr3OQ2IGXUtpNSXmdlvyRM+vQ7Abn/FxpLW/qqhZGB9vhQ==",
-      "dev": true,
-      "dependencies": {
-        "chevrotain": "^10.4.2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@newrelic/aws-sdk": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@newrelic/aws-sdk/-/aws-sdk-6.0.0.tgz",
-      "integrity": "sha512-17DwEvyDS9pAkV5kBSGtm2oIQbII0qOSAXSlU51MLA0Vp/PxNDTCBBFVgpKbGyKpPfudIJMGvh4jAmlzH3xIng==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/aws-sdk/-/aws-sdk-7.0.0.tgz",
+      "integrity": "sha512-/14Y9qYomDEzFrdXogqms2CGMI9hEJECzNBSqBLT53FY/uZh6SdI4Tr5u0sEOghjCdNyF2rseW7u63bAn09Pxw==",
       "dev": true,
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "newrelic": ">=8.7.0"
+        "newrelic": ">=10.0.0"
       }
     },
     "node_modules/@newrelic/eslint-config": {
@@ -1386,21 +1341,21 @@
       }
     },
     "node_modules/@newrelic/koa": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@newrelic/koa/-/koa-7.1.1.tgz",
-      "integrity": "sha512-QvO6Wmz+wws0vtrpqsZz3KVMbDySY7VbdIu99f9fuWd775yNCTz2n2VfQhdkBxWlSQSlR4gO0Uh8RWa4HUzb3g==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/koa/-/koa-8.0.0.tgz",
+      "integrity": "sha512-aaqEVLnRk12DzChCGbWthVQR4PxomqeNVVxnBF3txfHCMhDL2rkOjjcu8VYVoLkhVXrNtY0M226sYN/uqzQ+bQ==",
       "dev": true,
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "newrelic": ">=6.11.0"
       }
     },
     "node_modules/@newrelic/native-metrics": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@newrelic/native-metrics/-/native-metrics-9.0.1.tgz",
-      "integrity": "sha512-ZMCd6xW9PWhrWvg8Ik0oFU+XGFLbqRujh15qu3+7FJRI8163RBOD6SS8tsU0ydG8+LlaPDZQp/ODD4LvBXu5UA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/native-metrics/-/native-metrics-10.0.0.tgz",
+      "integrity": "sha512-0AFPPnj/wFT32mWK6vjc6LY0dZUOcHludZqPkHj2e3m+Zto3pWGk8PmRr1m3OGi+yVdHlEWbgHEAJ3T9lSAMBA==",
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
@@ -1410,7 +1365,7 @@
         "semver": "^7.5.2"
       },
       "engines": {
-        "node": ">=14",
+        "node": ">=16",
         "npm": ">=6"
       }
     },
@@ -1541,12 +1496,12 @@
       }
     },
     "node_modules/@newrelic/superagent": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@newrelic/superagent/-/superagent-6.0.0.tgz",
-      "integrity": "sha512-5nClQp9ACd4BvLusAgFHjjKLDgAaC+dKmIsRNOPC82LOLFaoOgxxtbecnDIJ0NWCKQS+WOdmXdgYutwH+e5dsA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/superagent/-/superagent-7.0.0.tgz",
+      "integrity": "sha512-fNB4NC+pJYYrFZRLcXaTb4Z7XFEfHi7fVQ3O9Qh10m/9CBM2W+Qc/6yyK9M1liRfgUGo5NOILRdjA23SS7720A==",
       "dev": true,
       "engines": {
-        "node": ">=14.0"
+        "node": ">=16.0"
       },
       "peerDependencies": {
         "newrelic": ">=6.11.0"
@@ -3506,6 +3461,13 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/@prisma/prisma-fmt-wasm": {
+      "version": "4.17.0-16.27eb2449f178cd9fe1a4b892d732cc4795f75085",
+      "resolved": "https://registry.npmjs.org/@prisma/prisma-fmt-wasm/-/prisma-fmt-wasm-4.17.0-16.27eb2449f178cd9fe1a4b892d732cc4795f75085.tgz",
+      "integrity": "sha512-zYz3rFwPB82mVlHGknAPdnSY/a308dhPOblxQLcZgZTDRtDXOE1MgxoRAys+jekwR4/bm3+rZDPs1xsFMsPZig==",
+      "dev": true,
+      "optional": true
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -4320,6 +4282,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-import-assertions": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
+      "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
+      "dev": true,
+      "peerDependencies": {
+        "acorn": "^8"
+      }
+    },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
@@ -4866,20 +4837,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/chevrotain": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-10.5.0.tgz",
-      "integrity": "sha512-Pkv5rBY3+CsHOYfV5g/Vs5JY9WTHHDEKOlohI2XeygaZhUeqhAlldZ8Hz9cRmxu709bvS08YzxHdTPHhffc13A==",
-      "dev": true,
-      "dependencies": {
-        "@chevrotain/cst-dts-gen": "10.5.0",
-        "@chevrotain/gast": "10.5.0",
-        "@chevrotain/types": "10.5.0",
-        "@chevrotain/utils": "10.5.0",
-        "lodash": "4.17.21",
-        "regexp-to-ast": "0.5.0"
-      }
-    },
     "node_modules/chokidar": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -4911,6 +4868,12 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
+      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
       "dev": true
     },
     "node_modules/clean-stack": {
@@ -6777,6 +6740,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/import-in-the-middle": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.4.2.tgz",
+      "integrity": "sha512-9WOz1Yh/cvO/p69sxRmhyQwrIGGSp7EIdcb+fFNVi7CzQGQB8U1/1XrKVSbEd/GNOAeM0peJtmi7+qphe7NvAw==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.8.2",
+        "acorn-import-assertions": "^1.9.0",
+        "cjs-module-lexer": "^1.2.2",
+        "module-details-from-path": "^1.0.3"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -8135,6 +8110,12 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "dev": true
     },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
+      "integrity": "sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A==",
+      "dev": true
+    },
     "node_modules/moment": {
       "version": "2.29.4",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
@@ -8182,24 +8163,25 @@
       }
     },
     "node_modules/newrelic": {
-      "version": "10.6.2",
-      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-10.6.2.tgz",
-      "integrity": "sha512-eCne93dEXcXsoFhjFnFJF6AO1PDhMZGA4G8i/sf5YjpaYXyUNfWacsDHQUM+0r1cf/BW8gL8HEVmIIW5uyAaXA==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-11.0.0.tgz",
+      "integrity": "sha512-uZEetgjfoscuuFNP7TH5BIKLv4vnfX27DV9y+Yb26ZrC3CNnVL+jBOAKY4+/vTxQiQHCi4uPfRyjw+1/3fOQXA==",
       "dev": true,
       "dependencies": {
         "@grpc/grpc-js": "^1.8.10",
         "@grpc/proto-loader": "^0.7.5",
-        "@mrleebo/prisma-ast": "^0.5.2",
-        "@newrelic/aws-sdk": "^6.0.0",
-        "@newrelic/koa": "^7.1.1",
+        "@newrelic/aws-sdk": "^7.0.0",
+        "@newrelic/koa": "^8.0.0",
         "@newrelic/security-agent": "0.2.1",
-        "@newrelic/superagent": "^6.0.0",
+        "@newrelic/superagent": "^7.0.0",
         "@tyriar/fibonacci-heap": "^2.0.7",
         "concat-stream": "^2.0.0",
         "https-proxy-agent": "^7.0.1",
+        "import-in-the-middle": "^1.4.2",
         "json-bigint": "^1.0.0",
         "json-stringify-safe": "^5.0.0",
         "readable-stream": "^3.6.1",
+        "require-in-the-middle": "^7.2.0",
         "semver": "^7.5.2",
         "winston-transport": "^4.5.0"
       },
@@ -8207,12 +8189,13 @@
         "newrelic-naming-rules": "bin/test-naming-rules.js"
       },
       "engines": {
-        "node": ">=14",
+        "node": ">=16",
         "npm": ">=6.0.0"
       },
       "optionalDependencies": {
         "@contrast/fn-inspect": "^3.3.0",
-        "@newrelic/native-metrics": "^9.0.1"
+        "@newrelic/native-metrics": "^10.0.0",
+        "@prisma/prisma-fmt-wasm": "^4.17.0-16.27eb2449f178cd9fe1a4b892d732cc4795f75085"
       }
     },
     "node_modules/newrelic/node_modules/concat-stream": {
@@ -9314,12 +9297,6 @@
         "esprima": "~4.0.0"
       }
     },
-    "node_modules/regexp-to-ast": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz",
-      "integrity": "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==",
-      "dev": true
-    },
     "node_modules/regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -9357,6 +9334,20 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-in-the-middle": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.2.0.tgz",
+      "integrity": "sha512-3TLx5TGyAY6AOqLBoXmHkNql0HIf2RGbuMgCDT2WO/uGVAPJs6h7Kl+bN6TIZGd9bWhWPwnDnTHGtW8Iu77sdw==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "module-details-from-path": "^1.0.3",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=8.6.0"
       }
     },
     "node_modules/require-main-filename": {
@@ -10280,17 +10271,6 @@
       "dependencies": {
         "@babel/template": "^7.22.5",
         "@babel/types": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/tap/node_modules/@babel/helper-get-function-arity": {
-      "version": "7.16.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -11647,11 +11627,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/tap/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/tap/node_modules/scheduler": {
       "version": "0.20.2",
       "dev": true,
@@ -11732,14 +11707,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT"
-    },
-    "node_modules/tap/node_modules/source-map": {
-      "version": "0.5.7",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/tap/node_modules/stack-utils": {
       "version": "2.0.6",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "koa": "^2.14.2",
     "lint-staged": "^11.0.0",
     "lockfile-lint": "^4.9.6",
-    "newrelic": "^10.3.0",
+    "newrelic": "^11.0.0",
     "prettier": "^2.3.2",
     "sinon": "^11.1.1",
     "tap": "^16.3.8"

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Wed Aug 16 2023 10:26:11 GMT-0400 (Eastern Daylight Time)",
+  "lastUpdated": "Mon Aug 28 2023 16:47:20 GMT-0400 (Eastern Daylight Time)",
   "projectName": "New Relic Test Utilities",
   "projectUrl": "https://github.com/newrelic/node-test-utilities",
   "includeOptDeps": false,
@@ -273,15 +273,15 @@
       "email": "liran.tal@gmail.com",
       "url": "https://github.com/lirantal"
     },
-    "newrelic@10.6.2": {
+    "newrelic@11.0.0": {
       "name": "newrelic",
-      "version": "10.6.2",
-      "range": "^10.3.0",
+      "version": "11.0.0",
+      "range": "^11.0.0",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/newrelic/node-newrelic",
-      "versionedRepoUrl": "https://github.com/newrelic/node-newrelic/tree/v10.6.2",
+      "versionedRepoUrl": "https://github.com/newrelic/node-newrelic/tree/v11.0.0",
       "licenseFile": "node_modules/newrelic/LICENSE",
-      "licenseUrl": "https://github.com/newrelic/node-newrelic/blob/v10.6.2/LICENSE",
+      "licenseUrl": "https://github.com/newrelic/node-newrelic/blob/v11.0.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "New Relic Node.js agent team",
       "email": "nodejs@newrelic.com"


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Updated the TestAgent to call `shimmer.registerHooks` and `shimmer.removeHooks` to set up instrumentation and remove it.

## Links
This assumes the work in https://github.com/newrelic/node-newrelic/pull/1758 is merged and released.  

## Details
This change isn't necessary until after release of the agent because I kept those functions.  Technically `shimmer.registerHooks` should now be called after bootstrapping instrumentation but it's ok for now.