### PR TITLE
chore: Added response for testing llm.token_count

### DIFF
--- a/lib/bedrock-server/responses/amazon.js
+++ b/lib/bedrock-server/responses/amazon.js
@@ -137,4 +137,35 @@ responses.set('text amazon bad stream', {
   body: 'bad stream'
 })
 
+responses.set('text amazon user token count callback response', {
+  headers: {
+    'content-type': contentType,
+    'x-amzn-requestid': reqId,
+    'x-amzn-bedrock-invocation-latency': '2420'
+  },
+  statusCode: 200,
+  body: {
+    inputTextTokenCount: 13,
+    results: [
+      {
+        tokenCount: 4,
+        outputText: '42',
+        completionReason: 'endoftext'
+      }
+    ]
+  }
+})
+
+responses.set('embed text amazon token count callback response', {
+  headers: {
+    'content-type': contentType,
+    'x-amzn-requestid': reqId
+  },
+  statusCode: 200,
+  body: {
+    embedding: [0.1, 0.2, 0.3, 0.4],
+    inputTextTokenCount: 13
+  }
+})
+
 module.exports = responses


### PR DESCRIPTION
## Proposed Release Notes

+ Added a new Amazon Titan LLM responses to support `token_count` work.

## Links

## Details

We need this to support https://github.com/newrelic/node-newrelic-aws-sdk/issues/263.