### PR TITLE
chore: Added instrumentation tracking to support newrelic issue 2033

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -467,7 +467,7 @@ Apache License
 
 ### async
 
-This product includes source derived from [async](https://github.com/caolan/async) ([v3.2.5](https://github.com/caolan/async/tree/v3.2.5)), distributed under the [MIT License](https://github.com/caolan/async/blob/v3.2.5/LICENSE):
+This product includes source derived from [async](https://github.com/caolan/async) ([v3.2.4](https://github.com/caolan/async/tree/v3.2.4)), distributed under the [MIT License](https://github.com/caolan/async/blob/v3.2.4/LICENSE):
 
 ```
 Copyright (c) 2010-2018 Caolan McMahon
@@ -1144,7 +1144,7 @@ This product includes source derived from [@newrelic/newrelic-oss-cli](https://g
 
 ### c8
 
-This product includes source derived from [c8](https://github.com/bcoe/c8) ([v7.14.0](https://github.com/bcoe/c8/tree/v7.14.0)), distributed under the [ISC License](https://github.com/bcoe/c8/blob/v7.14.0/LICENSE.txt):
+This product includes source derived from [c8](https://github.com/bcoe/c8) ([v7.13.0](https://github.com/bcoe/c8/tree/v7.13.0)), distributed under the [ISC License](https://github.com/bcoe/c8/blob/v7.13.0/LICENSE.txt):
 
 ```
 Copyright (c) 2017, Contributors
@@ -1166,7 +1166,7 @@ ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ### eslint-config-prettier
 
-This product includes source derived from [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier) ([v8.10.0](https://github.com/prettier/eslint-config-prettier/tree/v8.10.0)), distributed under the [MIT License](https://github.com/prettier/eslint-config-prettier/blob/v8.10.0/LICENSE):
+This product includes source derived from [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier) ([v8.8.0](https://github.com/prettier/eslint-config-prettier/tree/v8.8.0)), distributed under the [MIT License](https://github.com/prettier/eslint-config-prettier/blob/v8.8.0/LICENSE):
 
 ```
 The MIT License (MIT)
@@ -1273,7 +1273,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 ### eslint
 
-This product includes source derived from [eslint](https://github.com/eslint/eslint) ([v8.56.0](https://github.com/eslint/eslint/tree/v8.56.0)), distributed under the [MIT License](https://github.com/eslint/eslint/blob/v8.56.0/LICENSE):
+This product includes source derived from [eslint](https://github.com/eslint/eslint) ([v8.43.0](https://github.com/eslint/eslint/tree/v8.43.0)), distributed under the [MIT License](https://github.com/eslint/eslint/blob/v8.43.0/LICENSE):
 
 ```
 Copyright OpenJS Foundation and other contributors, <www.openjsf.org>
@@ -1439,7 +1439,7 @@ https://github.com/jmblog/color-themes-for-google-code-prettify
 
 ### koa
 
-This product includes source derived from [koa](https://github.com/koajs/koa) ([v2.15.0](https://github.com/koajs/koa/tree/v2.15.0)), distributed under the [MIT License](https://github.com/koajs/koa/blob/v2.15.0/LICENSE):
+This product includes source derived from [koa](https://github.com/koajs/koa) ([v2.14.2](https://github.com/koajs/koa/tree/v2.14.2)), distributed under the [MIT License](https://github.com/koajs/koa/blob/v2.14.2/LICENSE):
 
 ```
 (The MIT License)
@@ -1498,7 +1498,7 @@ SOFTWARE.
 
 ### lockfile-lint
 
-This product includes source derived from [lockfile-lint](https://github.com/lirantal/lockfile-lint) ([v4.12.1](https://github.com/lirantal/lockfile-lint/tree/v4.12.1)), distributed under the [Apache-2.0 License](https://github.com/lirantal/lockfile-lint/blob/v4.12.1/LICENSE):
+This product includes source derived from [lockfile-lint](https://github.com/lirantal/lockfile-lint) ([v4.10.1](https://github.com/lirantal/lockfile-lint/tree/v4.10.1)), distributed under the [Apache-2.0 License](https://github.com/lirantal/lockfile-lint/blob/v4.10.1/LICENSE):
 
 ```
 
@@ -1696,7 +1696,7 @@ This product includes source derived from [lockfile-lint](https://github.com/lir
 
 ### newrelic
 
-This product includes source derived from [newrelic](https://github.com/newrelic/node-newrelic) ([v11.10.2](https://github.com/newrelic/node-newrelic/tree/v11.10.2)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-newrelic/blob/v11.10.2/LICENSE):
+This product includes source derived from [newrelic](https://github.com/newrelic/node-newrelic) ([v11.13.0](https://github.com/newrelic/node-newrelic/tree/v11.13.0)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-newrelic/blob/v11.13.0/LICENSE):
 
 ```
                                  Apache License
@@ -1904,7 +1904,7 @@ This product includes source derived from [newrelic](https://github.com/newrelic
 
 ### prettier
 
-This product includes source derived from [prettier](https://github.com/prettier/prettier) ([v2.8.8](https://github.com/prettier/prettier/tree/v2.8.8)), distributed under the [MIT License](https://github.com/prettier/prettier/blob/v2.8.8/LICENSE):
+This product includes source derived from [prettier](https://github.com/prettier/prettier) ([v2.8.6](https://github.com/prettier/prettier/tree/v2.8.6)), distributed under the [MIT License](https://github.com/prettier/prettier/blob/v2.8.6/LICENSE):
 
 ```
 # Prettier license
@@ -7917,7 +7917,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ### tap
 
-This product includes source derived from [tap](https://github.com/tapjs/node-tap) ([v16.3.10](https://github.com/tapjs/node-tap/tree/v16.3.10)), distributed under the [ISC License](https://github.com/tapjs/node-tap/blob/v16.3.10/LICENSE):
+This product includes source derived from [tap](https://github.com/tapjs/node-tap) ([v16.3.8](https://github.com/tapjs/node-tap/tree/v16.3.8)), distributed under the [ISC License](https://github.com/tapjs/node-tap/blob/v16.3.8/LICENSE):
 
 ```
 The ISC License

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -11,6 +11,7 @@ const newRelicLoc = testUtil.getNewRelicLocation()
 const Agent = require(newRelicLoc + '/lib/agent')
 const API = require(newRelicLoc + '/api')
 const configurator = require(newRelicLoc + '/lib/config')
+const InstrumentationTracker = require(newRelicLoc + '/lib/instrumentation-tracker')
 const shimmer = require(newRelicLoc + '/lib/shimmer')
 
 module.exports = TestAgent
@@ -156,7 +157,14 @@ TestAgent.prototype.unload = function unload() {
   shimmer.removeHooks()
   shimmer.unwrapAll()
   shimmer.debug = false
-  shimmer.registeredInstrumentations = Object.create(null)
+  if (
+    Object.prototype.toString.call(shimmer.registeredInstrumentations) ===
+    '[object InstrumentationTracker]'
+  ) {
+    shimmer.registeredInstrumentations = new InstrumentationTracker()
+  } else {
+    shimmer.registeredInstrumentations = Object.create(null)
+  }
 
   testUtil.removeListenerByName(process, 'uncaughtException', '__NR_uncaughtExceptionHandler')
   testUtil.removeListenerByName(process, 'unhandledRejection', '__NR_unhandledRejectionHandler')

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "koa": "^2.14.2",
         "lint-staged": "^11.0.0",
         "lockfile-lint": "^4.9.6",
-        "newrelic": "^11.0.0",
+        "newrelic": "^11.14.0",
         "prettier": "^2.3.2",
         "sinon": "^11.1.1",
         "tap": "^16.3.8"
@@ -74,75 +74,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
-    "node_modules/@aws-crypto/ie11-detection": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
-      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
-    },
-    "node_modules/@aws-crypto/sha256-browser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
-      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
-      "dev": true,
-      "dependencies": {
-        "@aws-crypto/ie11-detection": "^3.0.0",
-        "@aws-crypto/sha256-js": "^3.0.0",
-        "@aws-crypto/supports-web-crypto": "^3.0.0",
-        "@aws-crypto/util": "^3.0.0",
-        "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-locate-window": "^3.0.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
-    },
-    "node_modules/@aws-crypto/sha256-js": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
-      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
-      "dev": true,
-      "dependencies": {
-        "@aws-crypto/util": "^3.0.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
-    },
-    "node_modules/@aws-crypto/supports-web-crypto": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
-      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
-    },
     "node_modules/@aws-crypto/util": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
@@ -158,436 +89,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
-    "node_modules/@aws-sdk/client-lambda": {
-      "version": "3.448.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.448.0.tgz",
-      "integrity": "sha512-Px2DwJF65vsi7NwHZBZa3rzxRvOX5x5XYZx9P3NoYAevwH5htyiTG8TpndgmBi2PdeCOpb5lKuqorne5+WuwXg==",
-      "dev": true,
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.445.0",
-        "@aws-sdk/core": "3.445.0",
-        "@aws-sdk/credential-provider-node": "3.445.0",
-        "@aws-sdk/middleware-host-header": "3.433.0",
-        "@aws-sdk/middleware-logger": "3.433.0",
-        "@aws-sdk/middleware-recursion-detection": "3.433.0",
-        "@aws-sdk/middleware-signing": "3.433.0",
-        "@aws-sdk/middleware-user-agent": "3.438.0",
-        "@aws-sdk/region-config-resolver": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-endpoints": "3.438.0",
-        "@aws-sdk/util-user-agent-browser": "3.433.0",
-        "@aws-sdk/util-user-agent-node": "3.437.0",
-        "@smithy/config-resolver": "^2.0.16",
-        "@smithy/eventstream-serde-browser": "^2.0.12",
-        "@smithy/eventstream-serde-config-resolver": "^2.0.12",
-        "@smithy/eventstream-serde-node": "^2.0.12",
-        "@smithy/fetch-http-handler": "^2.2.4",
-        "@smithy/hash-node": "^2.0.12",
-        "@smithy/invalid-dependency": "^2.0.12",
-        "@smithy/middleware-content-length": "^2.0.14",
-        "@smithy/middleware-endpoint": "^2.1.3",
-        "@smithy/middleware-retry": "^2.0.18",
-        "@smithy/middleware-serde": "^2.0.12",
-        "@smithy/middleware-stack": "^2.0.6",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/node-http-handler": "^2.1.8",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/smithy-client": "^2.1.12",
-        "@smithy/types": "^2.4.0",
-        "@smithy/url-parser": "^2.0.12",
-        "@smithy/util-base64": "^2.0.0",
-        "@smithy/util-body-length-browser": "^2.0.0",
-        "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.16",
-        "@smithy/util-defaults-mode-node": "^2.0.21",
-        "@smithy/util-endpoints": "^1.0.2",
-        "@smithy/util-retry": "^2.0.5",
-        "@smithy/util-stream": "^2.0.17",
-        "@smithy/util-utf8": "^2.0.0",
-        "@smithy/util-waiter": "^2.0.12",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso": {
-      "version": "3.445.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.445.0.tgz",
-      "integrity": "sha512-me4LvqNnu6kxi+sW7t0AgMv1Yi64ikas0x2+5jv23o6Csg32w0S0xOjCTKQYahOA5CMFunWvlkFIfxbqs+Uo7w==",
-      "dev": true,
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/core": "3.445.0",
-        "@aws-sdk/middleware-host-header": "3.433.0",
-        "@aws-sdk/middleware-logger": "3.433.0",
-        "@aws-sdk/middleware-recursion-detection": "3.433.0",
-        "@aws-sdk/middleware-user-agent": "3.438.0",
-        "@aws-sdk/region-config-resolver": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-endpoints": "3.438.0",
-        "@aws-sdk/util-user-agent-browser": "3.433.0",
-        "@aws-sdk/util-user-agent-node": "3.437.0",
-        "@smithy/config-resolver": "^2.0.16",
-        "@smithy/fetch-http-handler": "^2.2.4",
-        "@smithy/hash-node": "^2.0.12",
-        "@smithy/invalid-dependency": "^2.0.12",
-        "@smithy/middleware-content-length": "^2.0.14",
-        "@smithy/middleware-endpoint": "^2.1.3",
-        "@smithy/middleware-retry": "^2.0.18",
-        "@smithy/middleware-serde": "^2.0.12",
-        "@smithy/middleware-stack": "^2.0.6",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/node-http-handler": "^2.1.8",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/smithy-client": "^2.1.12",
-        "@smithy/types": "^2.4.0",
-        "@smithy/url-parser": "^2.0.12",
-        "@smithy/util-base64": "^2.0.0",
-        "@smithy/util-body-length-browser": "^2.0.0",
-        "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.16",
-        "@smithy/util-defaults-mode-node": "^2.0.21",
-        "@smithy/util-endpoints": "^1.0.2",
-        "@smithy/util-retry": "^2.0.5",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts": {
-      "version": "3.445.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.445.0.tgz",
-      "integrity": "sha512-ogbdqrS8x9O5BTot826iLnTQ6i4/F5BSi/74gycneCxYmAnYnyUBNOWVnynv6XZiEWyDJQCU2UtMd52aNGW1GA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/core": "3.445.0",
-        "@aws-sdk/credential-provider-node": "3.445.0",
-        "@aws-sdk/middleware-host-header": "3.433.0",
-        "@aws-sdk/middleware-logger": "3.433.0",
-        "@aws-sdk/middleware-recursion-detection": "3.433.0",
-        "@aws-sdk/middleware-sdk-sts": "3.433.0",
-        "@aws-sdk/middleware-signing": "3.433.0",
-        "@aws-sdk/middleware-user-agent": "3.438.0",
-        "@aws-sdk/region-config-resolver": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-endpoints": "3.438.0",
-        "@aws-sdk/util-user-agent-browser": "3.433.0",
-        "@aws-sdk/util-user-agent-node": "3.437.0",
-        "@smithy/config-resolver": "^2.0.16",
-        "@smithy/fetch-http-handler": "^2.2.4",
-        "@smithy/hash-node": "^2.0.12",
-        "@smithy/invalid-dependency": "^2.0.12",
-        "@smithy/middleware-content-length": "^2.0.14",
-        "@smithy/middleware-endpoint": "^2.1.3",
-        "@smithy/middleware-retry": "^2.0.18",
-        "@smithy/middleware-serde": "^2.0.12",
-        "@smithy/middleware-stack": "^2.0.6",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/node-http-handler": "^2.1.8",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/smithy-client": "^2.1.12",
-        "@smithy/types": "^2.4.0",
-        "@smithy/url-parser": "^2.0.12",
-        "@smithy/util-base64": "^2.0.0",
-        "@smithy/util-body-length-browser": "^2.0.0",
-        "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.16",
-        "@smithy/util-defaults-mode-node": "^2.0.21",
-        "@smithy/util-endpoints": "^1.0.2",
-        "@smithy/util-retry": "^2.0.5",
-        "@smithy/util-utf8": "^2.0.0",
-        "fast-xml-parser": "4.2.5",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/core": {
-      "version": "3.445.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.445.0.tgz",
-      "integrity": "sha512-6GYLElUG1QTOdmXG8zXa+Ull9IUeSeItKDYHKzHYfIkbsagMfYlf7wm9XIYlatjtgodNfZ3gPHAJfRyPmwKrsg==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/smithy-client": "^2.1.12",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.433.0.tgz",
-      "integrity": "sha512-Vl7Qz5qYyxBurMn6hfSiNJeUHSqfVUlMt0C1Bds3tCkl3IzecRWwyBOlxtxO3VCrgVeW3HqswLzCvhAFzPH6nQ==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.445.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.445.0.tgz",
-      "integrity": "sha512-R7IYSGjNZ5KKJwQJ2HNPemjpAMWvdce91i8w+/aHfqeGfTXrmYJu99PeGRyyBTKEumBaojyjTRvmO8HzS+/l7g==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.433.0",
-        "@aws-sdk/credential-provider-process": "3.433.0",
-        "@aws-sdk/credential-provider-sso": "3.445.0",
-        "@aws-sdk/credential-provider-web-identity": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/credential-provider-imds": "^2.0.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.445.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.445.0.tgz",
-      "integrity": "sha512-zI4k4foSjQRKNEsouculRcz7IbLfuqdFxypDLYwn+qPNMqJwWJ7VxOOeBSPUpHFcd7CLSfbHN2JAhQ7M02gPTA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.433.0",
-        "@aws-sdk/credential-provider-ini": "3.445.0",
-        "@aws-sdk/credential-provider-process": "3.433.0",
-        "@aws-sdk/credential-provider-sso": "3.445.0",
-        "@aws-sdk/credential-provider-web-identity": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/credential-provider-imds": "^2.0.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.433.0.tgz",
-      "integrity": "sha512-W7FcGlQjio9Y/PepcZGRyl5Bpwb0uWU7qIUCh+u4+q2mW4D5ZngXg8V/opL9/I/p4tUH9VXZLyLGwyBSkdhL+A==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.445.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.445.0.tgz",
-      "integrity": "sha512-gJz7kAiDecdhtApgXnxfZsXKsww8BnifDF9MAx9Dr4X6no47qYsCCS3XPuEyRiF9VebXvHOH0H260Zp3bVyniQ==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/client-sso": "3.445.0",
-        "@aws-sdk/token-providers": "3.438.0",
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.433.0.tgz",
-      "integrity": "sha512-RlwjP1I5wO+aPpwyCp23Mk8nmRbRL33hqRASy73c4JA2z2YiRua+ryt6MalIxehhwQU6xvXUKulJnPG9VaMFZg==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.433.0.tgz",
-      "integrity": "sha512-mBTq3UWv1UzeHG+OfUQ2MB/5GEkt5LTKFaUqzL7ESwzW8XtpBgXnjZvIwu3Vcd3sEetMwijwaGiJhY0ae/YyaA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.433.0.tgz",
-      "integrity": "sha512-We346Fb5xGonTGVZC9Nvqtnqy74VJzYuTLLiuuftA5sbNzftBDy/22QCfvYSTOAl3bvif+dkDUzQY2ihc5PwOQ==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.433.0.tgz",
-      "integrity": "sha512-HEvYC9PQlWY/ccUYtLvAlwwf1iCif2TSAmLNr3YTBRVa98x6jKL0hlCrHWYklFeqOGSKy6XhE+NGJMUII0/HaQ==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.433.0.tgz",
-      "integrity": "sha512-ORYbJnBejUyonFl5FwIqhvI3Cq6sAp9j+JpkKZtFNma9tFPdrhmYgfCeNH32H/wGTQV/tUoQ3luh0gA4cuk6DA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/middleware-signing": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.433.0.tgz",
-      "integrity": "sha512-jxPvt59NZo/epMNLNTu47ikmP8v0q217I6bQFGJG7JVFnfl36zDktMwGw+0xZR80qiK47/2BWrNpta61Zd2FxQ==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/signature-v4": "^2.0.0",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-middleware": "^2.0.5",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.438.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.438.0.tgz",
-      "integrity": "sha512-a+xHT1wOxT6EA6YyLmrfaroKWOkwwyiktUfXKM0FsUutGzNi4fKhb5NZ2al58NsXzHgHFrasSDp+Lqbd/X2cEw==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-endpoints": "3.438.0",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.433.0.tgz",
-      "integrity": "sha512-xpjRjCZW+CDFdcMmmhIYg81ST5UAnJh61IHziQEk0FXONrg4kjyYPZAOjEdzXQ+HxJQuGQLKPhRdzxmQnbX7pg==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-config-provider": "^2.0.0",
-        "@smithy/util-middleware": "^2.0.5",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/token-providers": {
-      "version": "3.438.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.438.0.tgz",
-      "integrity": "sha512-G2fUfTtU6/1ayYRMu0Pd9Ln4qYSvwJOWCqJMdkDgvXSwdgcOSOLsnAIk1AHGJDAvgLikdCzuyOsdJiexr9Vnww==",
-      "dev": true,
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/middleware-host-header": "3.433.0",
-        "@aws-sdk/middleware-logger": "3.433.0",
-        "@aws-sdk/middleware-recursion-detection": "3.433.0",
-        "@aws-sdk/middleware-user-agent": "3.438.0",
-        "@aws-sdk/region-config-resolver": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-endpoints": "3.438.0",
-        "@aws-sdk/util-user-agent-browser": "3.433.0",
-        "@aws-sdk/util-user-agent-node": "3.437.0",
-        "@smithy/config-resolver": "^2.0.16",
-        "@smithy/fetch-http-handler": "^2.2.4",
-        "@smithy/hash-node": "^2.0.12",
-        "@smithy/invalid-dependency": "^2.0.12",
-        "@smithy/middleware-content-length": "^2.0.14",
-        "@smithy/middleware-endpoint": "^2.1.3",
-        "@smithy/middleware-retry": "^2.0.18",
-        "@smithy/middleware-serde": "^2.0.12",
-        "@smithy/middleware-stack": "^2.0.6",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/node-http-handler": "^2.1.8",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/smithy-client": "^2.1.12",
-        "@smithy/types": "^2.4.0",
-        "@smithy/url-parser": "^2.0.12",
-        "@smithy/util-base64": "^2.0.0",
-        "@smithy/util-body-length-browser": "^2.0.0",
-        "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.16",
-        "@smithy/util-defaults-mode-node": "^2.0.21",
-        "@smithy/util-endpoints": "^1.0.2",
-        "@smithy/util-retry": "^2.0.5",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/types": {
       "version": "3.433.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
@@ -598,67 +99,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.438.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.438.0.tgz",
-      "integrity": "sha512-6VyPTq1kN3GWxwFt5DdZfOsr6cJZPLjWh0troY/0uUv3hK74C9o3Y0Xf/z8UAUvQFkVqZse12O0/BgPVMImvfA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/util-endpoints": "^1.0.2",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
-      "integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.433.0.tgz",
-      "integrity": "sha512-2Cf/Lwvxbt5RXvWFXrFr49vXv0IddiUwrZoAiwhDYxvsh+BMnh+NUFot+ZQaTrk/8IPZVDeLPWZRdVy00iaVXQ==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/types": "^2.4.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.437.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.437.0.tgz",
-      "integrity": "sha512-JVEcvWaniamtYVPem4UthtCNoTBCfFTwYj7Y3CrWZ2Qic4TqrwLkAfaBGtI2TGrhIClVr77uzLI6exqMTN7orA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
       }
     },
     "node_modules/@aws-sdk/util-utf8-browser": {
@@ -1356,9 +796,9 @@
       }
     },
     "node_modules/@newrelic/aws-sdk": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@newrelic/aws-sdk/-/aws-sdk-7.0.2.tgz",
-      "integrity": "sha512-nT19hzId0MbjR3v1ks5YetvNfrwIEgMfeai+T2pQkuWkjCsYm3z+OybLOYMCN66gueqOOqGTq60qhM4dFu5s5w==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/aws-sdk/-/aws-sdk-7.3.0.tgz",
+      "integrity": "sha512-6HBrd9SlHPeFI2MPH9s3KQUwJnuehHgn0boAtoGloiNL+dm6XbuTiNV1Deo1P2qspsCsf/luBvxM5b37MiGqVg==",
       "dev": true,
       "engines": {
         "node": ">=16.0.0"
@@ -1383,9 +823,9 @@
       }
     },
     "node_modules/@newrelic/koa": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@newrelic/koa/-/koa-8.0.1.tgz",
-      "integrity": "sha512-GyeZGKPllpUu6gWXRwVP/FlvE9+tU2lOprRiTdoXNM8jdVGL02IfHnvAzrIANoZoUdf3+Vev8NNeCup2Eojcvg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/koa/-/koa-9.0.0.tgz",
+      "integrity": "sha512-3PS14tkK0mNy9z01wZE7U5IYdI57bh/j//n1rCQNvl+5zTeiPsTmaSeKPQ21XI0RXDkSR5P909jIDt05M1+OsA==",
       "dev": true,
       "engines": {
         "node": ">=16.0.0"
@@ -1477,15 +917,28 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/@newrelic/security-agent": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@newrelic/security-agent/-/security-agent-0.4.0.tgz",
-      "integrity": "sha512-NWwKf1yBKOscdASGLsO3U7op8cH3k+WrGrge6Q8BY2bR/LWn4HJ6kLLIWwrUso77mYDWHtgxG0YteUCIRvUOlQ==",
+    "node_modules/@newrelic/ritm": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/ritm/-/ritm-7.2.0.tgz",
+      "integrity": "sha512-I4iVhm+wlTEDJXQT8EydF/U5vlR9bBHrtBGyvd/D9WCucoMtrPrCNyILQh9bZ+46E8QRE7zh6QEGyQcnc3qNMg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/client-lambda": "^3.405.0",
-        "axios": "1.6.0",
-        "check-disk-space": "3.3.1",
+        "debug": "^4.1.1",
+        "module-details-from-path": "^1.0.3",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/@newrelic/security-agent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@newrelic/security-agent/-/security-agent-1.0.1.tgz",
+      "integrity": "sha512-Ao5MTULa6CzI8a2poRdQ31jJA0Exv99eyewfMHYbJGAY3H4rj6TZs08rGtrDK9ZyjNTalM/DHhyyTTDq+FJM+Q==",
+      "dev": true,
+      "dependencies": {
+        "axios": "^1.6.5",
+        "check-disk-space": "^3.4.0",
         "content-type": "^1.0.5",
         "fast-safe-stringify": "^2.1.1",
         "find-package-json": "^1.2.0",
@@ -1504,7 +957,7 @@
         "unescape": "^1.0.1",
         "unescape-js": "^1.1.4",
         "uuid": "^9.0.1",
-        "ws": "^7.5.9"
+        "ws": "^8.14.2"
       }
     },
     "node_modules/@newrelic/security-agent/node_modules/argparse": {
@@ -3607,51 +3060,6 @@
       "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
       "dev": true
     },
-    "node_modules/@smithy/abort-controller": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.12.tgz",
-      "integrity": "sha512-YIJyefe1mi3GxKdZxEBEuzYOeQ9xpYfqnFmWzojCssRAuR7ycxwpoRQgp965vuW426xUAQhCV5rCaWElQ7XsaA==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/config-resolver": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.17.tgz",
-      "integrity": "sha512-iQ8Q8ojqiPqRKdybDI1g7HvG8EcnekRnH3DYeNTrT26vDuPq2nomyMCc0DZnPW+uAUcLCGZpAmGTAvEOYX55wA==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/node-config-provider": "^2.1.4",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-config-provider": "^2.0.0",
-        "@smithy/util-middleware": "^2.0.5",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/credential-provider-imds": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.1.0.tgz",
-      "integrity": "sha512-amqeueHM3i02S6z35WlXp7gejBnRloT5ctR/mQLlg/6LWGd70Avc2epzuuWtCptNg2ak5/yODD1fAVs9NPCyqg==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/node-config-provider": "^2.1.4",
-        "@smithy/property-provider": "^2.0.13",
-        "@smithy/types": "^2.4.0",
-        "@smithy/url-parser": "^2.0.12",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@smithy/eventstream-codec": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.1.1.tgz",
@@ -3685,523 +3093,10 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@smithy/eventstream-serde-browser": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-2.0.12.tgz",
-      "integrity": "sha512-0pi8QlU/pwutNshoeJcbKR1p7Ie5STd8UFAMX5xhSoSJjNlxIv/OsHbF023jscMRN2Prrqd6ToGgdCnsZVQjvg==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/eventstream-serde-universal": "^2.0.12",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/eventstream-serde-config-resolver": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-2.0.12.tgz",
-      "integrity": "sha512-I0XfwQkIX3gAnbrU5rLMkBSjTM9DHttdbLwf12CXmj7SSI5dT87PxtKLRrZGanaCMbdf2yCep+MW5/4M7IbvQA==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/eventstream-serde-node": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-2.0.12.tgz",
-      "integrity": "sha512-vf1vMHGOkG3uqN9x1zKOhnvW/XgvhJXWqjV6zZiT2FMjlEayugQ1mzpSqr7uf89+BzjTzuZKERmOsEAmewLbxw==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/eventstream-serde-universal": "^2.0.12",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/eventstream-serde-universal": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-2.0.12.tgz",
-      "integrity": "sha512-xZ3ZNpCxIND+q+UCy7y1n1/5VQEYicgSTNCcPqsKawX+Vd+6OcFX7gUHMyPzL8cZr+GdmJuxNleqHlH4giK2tw==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/eventstream-codec": "^2.0.12",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/fetch-http-handler": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.2.5.tgz",
-      "integrity": "sha512-m9yoTx+64XRSpCzWArOpvHeAuVfI2LFz2hDzgzjzCLlN8IIwzkFaCav5ShsYxx4iu9sXp09+on0a5VROY9+MFQ==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/querystring-builder": "^2.0.12",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-base64": "^2.0.1",
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@smithy/hash-node": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.13.tgz",
-      "integrity": "sha512-0L2BJ/uVLB+XMeuUfz2qhkcsgVL6IdO3ekROYTW7Wg+sWWqXm8fPN7RtqCrHjpAkPu4X23fsl2NpOjXsH/vNgA==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-buffer-from": "^2.0.0",
-        "@smithy/util-utf8": "^2.0.1",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/invalid-dependency": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.12.tgz",
-      "integrity": "sha512-p5Y+iMHV3SoEpy3VSR7mifbreHQwVSvHSAz/m4GdoXfOzKzaYC8hYv10Ks7Deblkf7lhas8U+lAp9ThbBM+ZXA==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@smithy/is-array-buffer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
-      "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-content-length": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.14.tgz",
-      "integrity": "sha512-poUNgKTw9XwPXfX9nEHpVgrMNVpaSMZbshqvPxFVoalF4wp6kRzYKOfdesSVectlQ51VtigoLfbXcdyPwvxgTg==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-endpoint": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.1.5.tgz",
-      "integrity": "sha512-eRhI0mI9tnkpmLwJbprV+MdlPyOMe8tFtVrNFMUlgOQrJeYv5AD5UFRn/KhgNX1vO1pVgpPtD9R+cRuFhj/lIQ==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/middleware-serde": "^2.0.12",
-        "@smithy/node-config-provider": "^2.1.4",
-        "@smithy/shared-ini-file-loader": "^2.2.3",
-        "@smithy/types": "^2.4.0",
-        "@smithy/url-parser": "^2.0.12",
-        "@smithy/util-middleware": "^2.0.5",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-retry": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.19.tgz",
-      "integrity": "sha512-VMS1GHxLpRnuLHrPTj/nb9aD99jJsNzWX07F00fIuV9lkz3lWP7RUM7P1aitm0+4YfhShPn+Wri8/CuoqPOziA==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/node-config-provider": "^2.1.4",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/service-error-classification": "^2.0.5",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-middleware": "^2.0.5",
-        "@smithy/util-retry": "^2.0.5",
-        "tslib": "^2.5.0",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-serde": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.12.tgz",
-      "integrity": "sha512-IBeco157lIScecq2Z+n0gq56i4MTnfKxS7rbfrAORveDJgnbBAaEQgYqMqp/cYqKrpvEXcyTjwKHrBjCCIZh2A==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-stack": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.6.tgz",
-      "integrity": "sha512-YSvNZeOKWLJ0M/ycxwDIe2Ztkp6Qixmcml1ggsSv2fdHKGkBPhGrX5tMzPGMI1yyx55UEYBi2OB4s+RriXX48A==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/node-config-provider": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.1.4.tgz",
-      "integrity": "sha512-kROLnHFatpimtmZ8YefsRRb5OJ8LVIVNhUWp67KHL4D2Vjd+WpIHMzWtkLLV4p0qXpY+IxmwcL2d2XMPn8ppsQ==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/property-provider": "^2.0.13",
-        "@smithy/shared-ini-file-loader": "^2.2.3",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/node-http-handler": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.1.8.tgz",
-      "integrity": "sha512-KZylM7Wff/So5SmCiwg2kQNXJ+RXgz34wkxS7WNwIUXuZrZZpY/jKJCK+ZaGyuESDu3TxcaY+zeYGJmnFKbQsA==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/abort-controller": "^2.0.12",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/querystring-builder": "^2.0.12",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/property-provider": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.13.tgz",
-      "integrity": "sha512-VJqUf2CbsQX6uUiC5dUPuoEATuFjkbkW3lJHbRnpk9EDC9X+iKqhfTK+WP+lve5EQ9TcCI1Q6R7hrg41FyC54w==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/protocol-http": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.8.tgz",
-      "integrity": "sha512-SHJvYeWq8q0FK8xHk+xjV9dzDUDjFMT+G1pZbV+XB6OVoac/FSVshlMNPeUJ8AmSkcDKHRu5vASnRqZHgD3qhw==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/querystring-builder": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.12.tgz",
-      "integrity": "sha512-cDbF07IuCjiN8CdGvPzfJjXIrmDSelScRfyJYrYBNBbKl2+k7QD/KqiHhtRyEKgID5mmEVrV6KE6L/iPJ98sFw==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-uri-escape": "^2.0.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/querystring-parser": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.12.tgz",
-      "integrity": "sha512-fytyTcXaMzPBuNtPlhj5v6dbl4bJAnwKZFyyItAGt4Tgm9HFPZNo7a9r1SKPr/qdxUEBzvL9Rh+B9SkTX3kFxg==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/service-error-classification": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.5.tgz",
-      "integrity": "sha512-M0SeJnEgD2ywJyV99Fb1yKFzmxDe9JfpJiYTVSRMyRLc467BPU0qsuuDPzMCdB1mU8M8u1rVOdkqdoyFN8UFTw==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/types": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.2.3.tgz",
-      "integrity": "sha512-VDyhCNycPbNkPidMnBgYQeSwJkoATRFm5VrveVqIPAjsdGutf7yZpPycuDWW9bRFnuuwaBhCC0pA7KCH0+2wrg==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/signature-v4": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.13.tgz",
-      "integrity": "sha512-odJl+t0YdI2wT61Nr6qvlN+I8APNFWTtPr90CqVyHidb4Kyzq3lFSiY5T6I+IdvCV6BbNZ2btUYm2R6ae7zWYw==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/eventstream-codec": "^2.0.12",
-        "@smithy/is-array-buffer": "^2.0.0",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-hex-encoding": "^2.0.0",
-        "@smithy/util-middleware": "^2.0.5",
-        "@smithy/util-uri-escape": "^2.0.0",
-        "@smithy/util-utf8": "^2.0.1",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/smithy-client": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.1.13.tgz",
-      "integrity": "sha512-iFqrjps6K/eLNbDKppyp5gCCZyEtv/BYMlDSBXwwHIrwV7sZ8l8r6OGAcg1a69j4Id1uJccYppaTpW5G1BLhsA==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/middleware-stack": "^2.0.6",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-stream": "^2.0.18",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@smithy/types": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
       "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/url-parser": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.12.tgz",
-      "integrity": "sha512-qgkW2mZqRvlNUcBkxYB/gYacRaAdck77Dk3/g2iw0S9F0EYthIS3loGfly8AwoWpIvHKhkTsCXXQfzksgZ4zIA==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/querystring-parser": "^2.0.12",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@smithy/util-base64": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.0.1.tgz",
-      "integrity": "sha512-DlI6XFYDMsIVN+GH9JtcRp3j02JEVuWIn/QOZisVzpIAprdsxGveFed0bjbMRCqmIFe8uetn5rxzNrBtIGrPIQ==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.0.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/util-body-length-browser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.0.0.tgz",
-      "integrity": "sha512-JdDuS4ircJt+FDnaQj88TzZY3+njZ6O+D3uakS32f2VNnDo3vyEuNdBOh/oFd8Df1zSZOuH1HEChk2AOYDezZg==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@smithy/util-body-length-node": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.1.0.tgz",
-      "integrity": "sha512-/li0/kj/y3fQ3vyzn36NTLGmUwAICb7Jbe/CsWCktW363gh1MOcpEcSO3mJ344Gv2dqz8YJCLQpb6hju/0qOWw==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/util-buffer-from": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
-      "integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/is-array-buffer": "^2.0.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/util-config-provider": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.0.0.tgz",
-      "integrity": "sha512-xCQ6UapcIWKxXHEU4Mcs2s7LcFQRiU3XEluM2WcCjjBtQkUN71Tb+ydGmJFPxMUrW/GWMgQEEGipLym4XG0jZg==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.17.tgz",
-      "integrity": "sha512-kAJNbe3n4PYOpudOUjcyZ3MZ8G3xWt/oV+lZp/y87Rmd5/evLEc5VVuEW6u030aY8L3Uw2PX6cVA5UuJBIN14Q==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/property-provider": "^2.0.13",
-        "@smithy/smithy-client": "^2.1.13",
-        "@smithy/types": "^2.4.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "2.0.23",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.23.tgz",
-      "integrity": "sha512-S319Pjqmo4Quq6D9Ytt/XLMpS0PgbZZ7WAjjs3+6h0b/fRkUe5qppE115plpZZvN1EixDbh9R/k30tDOJayYdA==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/config-resolver": "^2.0.17",
-        "@smithy/credential-provider-imds": "^2.1.0",
-        "@smithy/node-config-provider": "^2.1.4",
-        "@smithy/property-provider": "^2.0.13",
-        "@smithy/smithy-client": "^2.1.13",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@smithy/util-endpoints": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.0.3.tgz",
-      "integrity": "sha512-rMYXLMdAMVbJAEHhNlCSJsAxo3NG3lcPja7WmesjAbNrMSyYZ6FnHHTy8kzRhddn4eAtLvPBSO6LiBB21gCoHQ==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/node-config-provider": "^2.1.4",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@smithy/util-hex-encoding": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
-      "integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/util-middleware": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.5.tgz",
-      "integrity": "sha512-1lyT3TcaMJQe+OFfVI+TlomDkPuVzb27NZYdYtmSTltVmLaUjdCyt4KE+OH1CnhZKsz4/cdCL420Lg9UH5Z2Mw==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/util-retry": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.5.tgz",
-      "integrity": "sha512-x3t1+MQAJ6QONk3GTbJNcugCFDVJ+Bkro5YqQQK1EyVesajNDqxFtCx9WdOFNGm/Cbm7tUdwVEmfKQOJoU2Vtw==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/service-error-classification": "^2.0.5",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@smithy/util-stream": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.18.tgz",
-      "integrity": "sha512-e/a7JrmHTy+gxHjdJKHQFyK8X2SCoJEaBXTrs5Q/HS69a3P4P0Mbu1znKFKFM/fDtppCxPCO0IcIbNvbVSEJ8w==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/fetch-http-handler": "^2.2.5",
-        "@smithy/node-http-handler": "^2.1.8",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-base64": "^2.0.1",
-        "@smithy/util-buffer-from": "^2.0.0",
-        "@smithy/util-hex-encoding": "^2.0.0",
-        "@smithy/util-utf8": "^2.0.1",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/util-uri-escape": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz",
-      "integrity": "sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -4238,20 +3133,6 @@
       "integrity": "sha512-clhNjbyfqIv9Md2Mg6FffGVrJxw7bgK7s3Iax36xnfVj6cg0fUG7I4RH0XgXJF8bxi+saY5HR21g2UPKSxVCXg==",
       "dependencies": {
         "@smithy/is-array-buffer": "^2.1.1",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/util-waiter": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.0.12.tgz",
-      "integrity": "sha512-3sENmyVa1NnOPoiT2NCApPmu7ukP7S/v7kL9IxNmnygkDldn7/yK0TP42oPJLwB2k3mospNsSePIlqdXEUyPHA==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/abort-controller": "^2.0.12",
-        "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -4320,9 +3201,9 @@
       "dev": true
     },
     "node_modules/@types/qs": {
-      "version": "6.9.10",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.10.tgz",
-      "integrity": "sha512-3Gnx08Ns1sEoCrWssEgTSJs/rsT2vhGP+Ja9cnnk9k4ALxinORlQneLXFeFKOTJMOeZUFD1s7w+w2AphTpvzZw==",
+      "version": "6.9.13",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.13.tgz",
+      "integrity": "sha512-iLR+1vTTJ3p0QaOUq6ACbY1mzKTODFDT/XedZI8BksOotFmL4ForwDfRQ/DZeuTHR7/2i4lI1D203gdfxuqTlA==",
       "dev": true
     },
     "node_modules/@types/semver": {
@@ -4603,12 +3484,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.0.tgz",
-      "integrity": "sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
       "dev": true,
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -4694,12 +3575,6 @@
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-      "dev": true
-    },
-    "node_modules/bowser": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
       "dev": true
     },
     "node_modules/brace-expansion": {
@@ -4844,14 +3719,19 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
-      "integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
       "dev": true,
       "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.1",
-        "set-function-length": "^1.1.1"
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4937,12 +3817,12 @@
       }
     },
     "node_modules/check-disk-space": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/check-disk-space/-/check-disk-space-3.3.1.tgz",
-      "integrity": "sha512-iOrT8yCZjSnyNZ43476FE2rnssvgw5hnuwOM0hm8Nj1qa0v4ieUUEbCyxxsEliaoDUb/75yCOL71zkDiDBLbMQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/check-disk-space/-/check-disk-space-3.4.0.tgz",
+      "integrity": "sha512-drVkSqfwA+TvuEhFipiR1OC9boEGZL5RrWvVsOthdcvQNXyCCuKkEiTOTXZ7qxSf/GLwq4GvzfrQD/Wz325hgw==",
       "dev": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=16"
       }
     },
     "node_modules/chokidar": {
@@ -5455,17 +4335,20 @@
       }
     },
     "node_modules/define-data-property": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
-      "integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "dev": true,
       "dependencies": {
-        "get-intrinsic": "^1.2.1",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.0"
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/delayed-stream": {
@@ -5609,6 +4492,27 @@
       "dev": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.2.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/es6-error": {
@@ -6143,28 +5047,6 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true
     },
-    "node_modules/fast-xml-parser": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
-      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "dependencies": {
-        "strnum": "^1.0.5"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
@@ -6441,15 +5323,19 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
-      "integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
       "dev": true,
       "dependencies": {
+        "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
         "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3",
         "hasown": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6603,21 +5489,21 @@
       }
     },
     "node_modules/has-property-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
-      "integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "dev": true,
       "dependencies": {
-        "get-intrinsic": "^1.2.2"
+        "es-define-property": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
+      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
       "dev": true,
       "engines": {
         "node": ">= 0.4"
@@ -6689,9 +5575,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
-      "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
       "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -6707,9 +5593,9 @@
       "dev": true
     },
     "node_modules/html-entities": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.4.0.tgz",
-      "integrity": "sha512-igBTJcNNNhvZFRtm8uA6xMY6xYleeDwn3PeBCkDz7tHttv4F2hsDI2aPgNERWzvRcNYHNT3ymRaQzllmXj4YsQ==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.5.2.tgz",
+      "integrity": "sha512-K//PSRMQk4FZ78Kyau+mZurHn3FH0Vwr+H36eE0rPbeYkRRi9YxceYPhuN60UwWorxyKHhqoAJl2OFKa4BVtaA==",
       "dev": true,
       "funding": [
         {
@@ -6902,9 +5788,9 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.4.2.tgz",
-      "integrity": "sha512-9WOz1Yh/cvO/p69sxRmhyQwrIGGSp7EIdcb+fFNVi7CzQGQB8U1/1XrKVSbEd/GNOAeM0peJtmi7+qphe7NvAw==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.3.tgz",
+      "integrity": "sha512-R2I11NRi0lI3jD2+qjqyVlVEahsejw7LDnYEbGb47QEFjczE3bZYsmWheCTQA+LFs2DzOQxR7Pms7naHW1V4bQ==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.8.2",
@@ -8324,26 +7210,26 @@
       }
     },
     "node_modules/newrelic": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-11.5.0.tgz",
-      "integrity": "sha512-y1jZSAhcCKvzPXXTk29kEMKNl42RvN/nRe5WU7Fzi4nmxUxdn+m5GfSVu89hEsmJYJ8i2Rc6s4RGFX0kn9Hung==",
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-11.14.0.tgz",
+      "integrity": "sha512-12LLm7wN/n1APOe3qUcijpEE7sLgxiZ/ApAKB18Sou6FBpplsnCoBHuTtIOThpLEFjRJYxpw5PaOQGzb8gauZg==",
       "dev": true,
       "dependencies": {
         "@grpc/grpc-js": "^1.9.4",
         "@grpc/proto-loader": "^0.7.5",
-        "@newrelic/aws-sdk": "^7.0.2",
-        "@newrelic/koa": "^8.0.1",
-        "@newrelic/security-agent": "0.4.0",
+        "@newrelic/aws-sdk": "^7.3.0",
+        "@newrelic/koa": "^9.0.0",
+        "@newrelic/ritm": "^7.2.0",
+        "@newrelic/security-agent": "1.0.1",
         "@newrelic/superagent": "^7.0.1",
         "@tyriar/fibonacci-heap": "^2.0.7",
         "concat-stream": "^2.0.0",
         "https-proxy-agent": "^7.0.1",
-        "import-in-the-middle": "^1.4.2",
+        "import-in-the-middle": "^1.6.0",
         "json-bigint": "^1.0.0",
         "json-stringify-safe": "^5.0.0",
         "module-details-from-path": "^1.0.3",
         "readable-stream": "^3.6.1",
-        "require-in-the-middle": "^7.2.0",
         "semver": "^7.5.2",
         "winston-transport": "^4.5.0"
       },
@@ -9339,12 +8225,12 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.11.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
-      "integrity": "sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.0.tgz",
+      "integrity": "sha512-trVZiI6RMOkO476zLGaBIzszOdFPnCCXHPG9kn0yuS1uz6xdVxPfZdB3vUig9pxPFDM9BRAgz/YUIVQ1/vuiUg==",
       "dev": true,
       "dependencies": {
-        "side-channel": "^1.0.4"
+        "side-channel": "^1.0.6"
       },
       "engines": {
         "node": ">=0.6"
@@ -9496,20 +8382,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/require-in-the-middle": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.2.0.tgz",
-      "integrity": "sha512-3TLx5TGyAY6AOqLBoXmHkNql0HIf2RGbuMgCDT2WO/uGVAPJs6h7Kl+bN6TIZGd9bWhWPwnDnTHGtW8Iu77sdw==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "module-details-from-path": "^1.0.3",
-        "resolve": "^1.22.1"
-      },
-      "engines": {
-        "node": ">=8.6.0"
       }
     },
     "node_modules/require-main-filename": {
@@ -9694,15 +8566,17 @@
       "dev": true
     },
     "node_modules/set-function-length": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
-      "integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
       "dev": true,
       "dependencies": {
-        "define-data-property": "^1.1.1",
-        "get-intrinsic": "^1.2.1",
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
         "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.0"
+        "has-property-descriptors": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -9736,14 +8610,18 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
+      "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
+        "call-bind": "^1.0.7",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.4",
+        "object-inspect": "^1.13.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -10109,12 +8987,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/strnum": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
-      "dev": true
     },
     "node_modules/supports-color": {
       "version": "5.5.0",
@@ -12783,16 +11655,16 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
+      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
       "dev": true,
       "engines": {
-        "node": ">=8.3.0"
+        "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "koa": "^2.14.2",
     "lint-staged": "^11.0.0",
     "lockfile-lint": "^4.9.6",
-    "newrelic": "^11.0.0",
+    "newrelic": "^11.14.0",
     "prettier": "^2.3.2",
     "sinon": "^11.1.1",
     "tap": "^16.3.8"

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Thu Feb 01 2024 09:00:54 GMT-0500 (Eastern Standard Time)",
+  "lastUpdated": "Wed Mar 20 2024 10:34:22 GMT-0400 (Eastern Daylight Time)",
   "projectName": "New Relic Test Utilities",
   "projectUrl": "https://github.com/newrelic/node-test-utilities",
   "includeOptDeps": false,
@@ -31,15 +31,15 @@
       "publisher": "AWS SDK for JavaScript Team",
       "url": "https://aws.amazon.com/javascript/"
     },
-    "async@3.2.5": {
+    "async@3.2.4": {
       "name": "async",
-      "version": "3.2.5",
+      "version": "3.2.4",
       "range": "^3.2.3",
       "licenses": "MIT",
       "repoUrl": "https://github.com/caolan/async",
-      "versionedRepoUrl": "https://github.com/caolan/async/tree/v3.2.5",
+      "versionedRepoUrl": "https://github.com/caolan/async/tree/v3.2.4",
       "licenseFile": "node_modules/async/LICENSE",
-      "licenseUrl": "https://github.com/caolan/async/blob/v3.2.5/LICENSE",
+      "licenseUrl": "https://github.com/caolan/async/blob/v3.2.4/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Caolan McMahon"
     },
@@ -161,28 +161,28 @@
       "licenseTextSource": "file",
       "publisher": "New Relic"
     },
-    "c8@7.14.0": {
+    "c8@7.13.0": {
       "name": "c8",
-      "version": "7.14.0",
+      "version": "7.13.0",
       "range": "^7.12.0",
       "licenses": "ISC",
       "repoUrl": "https://github.com/bcoe/c8",
-      "versionedRepoUrl": "https://github.com/bcoe/c8/tree/v7.14.0",
+      "versionedRepoUrl": "https://github.com/bcoe/c8/tree/v7.13.0",
       "licenseFile": "node_modules/c8/LICENSE.txt",
-      "licenseUrl": "https://github.com/bcoe/c8/blob/v7.14.0/LICENSE.txt",
+      "licenseUrl": "https://github.com/bcoe/c8/blob/v7.13.0/LICENSE.txt",
       "licenseTextSource": "file",
       "publisher": "Ben Coe",
       "email": "ben@npmjs.com"
     },
-    "eslint-config-prettier@8.10.0": {
+    "eslint-config-prettier@8.8.0": {
       "name": "eslint-config-prettier",
-      "version": "8.10.0",
+      "version": "8.8.0",
       "range": "^8.3.0",
       "licenses": "MIT",
       "repoUrl": "https://github.com/prettier/eslint-config-prettier",
-      "versionedRepoUrl": "https://github.com/prettier/eslint-config-prettier/tree/v8.10.0",
+      "versionedRepoUrl": "https://github.com/prettier/eslint-config-prettier/tree/v8.8.0",
       "licenseFile": "node_modules/eslint-config-prettier/LICENSE",
-      "licenseUrl": "https://github.com/prettier/eslint-config-prettier/blob/v8.10.0/LICENSE",
+      "licenseUrl": "https://github.com/prettier/eslint-config-prettier/blob/v8.8.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Simon Lydell"
     },
@@ -222,15 +222,15 @@
       "licenseTextSource": "file",
       "publisher": "Teddy Katz"
     },
-    "eslint@8.56.0": {
+    "eslint@8.43.0": {
       "name": "eslint",
-      "version": "8.56.0",
+      "version": "8.43.0",
       "range": "^8.43.0",
       "licenses": "MIT",
       "repoUrl": "https://github.com/eslint/eslint",
-      "versionedRepoUrl": "https://github.com/eslint/eslint/tree/v8.56.0",
+      "versionedRepoUrl": "https://github.com/eslint/eslint/tree/v8.43.0",
       "licenseFile": "node_modules/eslint/LICENSE",
-      "licenseUrl": "https://github.com/eslint/eslint/blob/v8.56.0/LICENSE",
+      "licenseUrl": "https://github.com/eslint/eslint/blob/v8.43.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Nicholas C. Zakas",
       "email": "nicholas+npm@nczconsulting.com"
@@ -261,15 +261,15 @@
       "publisher": "Michael Mathews",
       "email": "micmath@gmail.com"
     },
-    "koa@2.15.0": {
+    "koa@2.14.2": {
       "name": "koa",
-      "version": "2.15.0",
+      "version": "2.14.2",
       "range": "^2.14.2",
       "licenses": "MIT",
       "repoUrl": "https://github.com/koajs/koa",
-      "versionedRepoUrl": "https://github.com/koajs/koa/tree/v2.15.0",
+      "versionedRepoUrl": "https://github.com/koajs/koa/tree/v2.14.2",
       "licenseFile": "node_modules/koa/LICENSE",
-      "licenseUrl": "https://github.com/koajs/koa/blob/v2.15.0/LICENSE",
+      "licenseUrl": "https://github.com/koajs/koa/blob/v2.14.2/LICENSE",
       "licenseTextSource": "file"
     },
     "lint-staged@11.2.6": {
@@ -285,42 +285,42 @@
       "publisher": "Andrey Okonetchnikov",
       "email": "andrey@okonet.ru"
     },
-    "lockfile-lint@4.12.1": {
+    "lockfile-lint@4.10.1": {
       "name": "lockfile-lint",
-      "version": "4.12.1",
+      "version": "4.10.1",
       "range": "^4.9.6",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/lirantal/lockfile-lint",
-      "versionedRepoUrl": "https://github.com/lirantal/lockfile-lint/tree/v4.12.1",
+      "versionedRepoUrl": "https://github.com/lirantal/lockfile-lint/tree/v4.10.1",
       "licenseFile": "node_modules/lockfile-lint/LICENSE",
-      "licenseUrl": "https://github.com/lirantal/lockfile-lint/blob/v4.12.1/LICENSE",
+      "licenseUrl": "https://github.com/lirantal/lockfile-lint/blob/v4.10.1/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Liran Tal",
       "email": "liran.tal@gmail.com",
       "url": "https://github.com/lirantal"
     },
-    "newrelic@11.10.2": {
+    "newrelic@11.13.0": {
       "name": "newrelic",
-      "version": "11.10.2",
-      "range": "^11.0.0",
+      "version": "11.13.0",
+      "range": "^11.14.0",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/newrelic/node-newrelic",
-      "versionedRepoUrl": "https://github.com/newrelic/node-newrelic/tree/v11.10.2",
+      "versionedRepoUrl": "https://github.com/newrelic/node-newrelic/tree/v11.13.0",
       "licenseFile": "node_modules/newrelic/LICENSE",
-      "licenseUrl": "https://github.com/newrelic/node-newrelic/blob/v11.10.2/LICENSE",
+      "licenseUrl": "https://github.com/newrelic/node-newrelic/blob/v11.13.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "New Relic Node.js agent team",
       "email": "nodejs@newrelic.com"
     },
-    "prettier@2.8.8": {
+    "prettier@2.8.6": {
       "name": "prettier",
-      "version": "2.8.8",
+      "version": "2.8.6",
       "range": "^2.3.2",
       "licenses": "MIT",
       "repoUrl": "https://github.com/prettier/prettier",
-      "versionedRepoUrl": "https://github.com/prettier/prettier/tree/v2.8.8",
+      "versionedRepoUrl": "https://github.com/prettier/prettier/tree/v2.8.6",
       "licenseFile": "node_modules/prettier/LICENSE",
-      "licenseUrl": "https://github.com/prettier/prettier/blob/v2.8.8/LICENSE",
+      "licenseUrl": "https://github.com/prettier/prettier/blob/v2.8.6/LICENSE",
       "licenseTextSource": "file",
       "publisher": "James Long"
     },
@@ -336,15 +336,15 @@
       "licenseTextSource": "file",
       "publisher": "Christian Johansen"
     },
-    "tap@16.3.10": {
+    "tap@16.3.8": {
       "name": "tap",
-      "version": "16.3.10",
+      "version": "16.3.8",
       "range": "^16.3.8",
       "licenses": "ISC",
       "repoUrl": "https://github.com/tapjs/node-tap",
-      "versionedRepoUrl": "https://github.com/tapjs/node-tap/tree/v16.3.10",
+      "versionedRepoUrl": "https://github.com/tapjs/node-tap/tree/v16.3.8",
       "licenseFile": "node_modules/tap/LICENSE",
-      "licenseUrl": "https://github.com/tapjs/node-tap/blob/v16.3.10/LICENSE",
+      "licenseUrl": "https://github.com/tapjs/node-tap/blob/v16.3.8/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Isaac Z. Schlueter",
       "email": "i@izs.me",


### PR DESCRIPTION
This PR updates the minimum version of `newrelic` in order to utilize the instrumentation tracker instead of `Object.create(null)` in the agent helper.