### PR TITLE
ci: Removed `use_new_release` input from prepare release workflow

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -18,5 +18,4 @@ jobs:
     uses: newrelic/node-newrelic/.github/workflows/prep-release.yml@main
     with:
       release_type: ${{ github.event.inputs.release_type }}
-      use_new_release: ${{ vars.USE_NEW_RELEASE }}
       changelog_file: CHANGELOG.md


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

We no longer need to use `use_new_release` input variable in the prepare release workflow since that will be the only option. Also added `changelog_file` input since it was missing. 

## Related Issues

Related to: https://github.com/newrelic/node-newrelic/pull/2124
Partially fixes: https://github.com/newrelic/node-newrelic/issues/2113

## ToDo

- [ ]  Remove USE_NEW_RELEASE from github action variables
