### PR TITLE
feat: Added a quiet mode printer to versioned-tests

### DIFF
--- a/bin/version-manager.js
+++ b/bin/version-manager.js
@@ -61,7 +61,7 @@ function int(val) {
 }
 
 function printMode(mode) {
-  if (['pretty', 'simple'].indexOf(mode) === -1) {
+  if (['pretty', 'simple', 'quiet'].indexOf(mode) === -1) {
     console.error('Invalid print mode "' + mode + '"')
     process.exit(5)
   }
@@ -90,10 +90,24 @@ function run(files, patterns) {
   const mode = cmd.major ? 'major' : cmd.patch ? 'patch' : 'minor'
 
   // Create our test structures.
-  const viewer =
-    process.env.TRAVIS || cmd.print === 'simple'
-      ? new printers.SimplePrinter(files, { refresh: 100 })
-      : new printers.PrettyPrinter(files, { refresh: 100 })
+  let viewer
+  switch (cmd.print) {
+    case 'default':
+    case 'simple': {
+      viewer = new printers.SimplePrinter(files, { refresh: 100 })
+      break
+    }
+
+    case 'pretty': {
+      viewer = new printers.PrettyPrinter(files, { refresh: 100 })
+      break
+    }
+
+    case 'quiet': {
+      viewer = new printers.QuietPrinter(files, { refresh: 100 })
+      break
+    }
+  }
 
   const runner = new Suite(directories, {
     limit: maxParallelRuns,

--- a/lib/versioned/printers/index.js
+++ b/lib/versioned/printers/index.js
@@ -7,3 +7,4 @@
 
 exports.PrettyPrinter = require('./pretty')
 exports.SimplePrinter = require('./simple')
+exports.QuietPrinter = require('./quiet')

--- a/lib/versioned/printers/quiet.js
+++ b/lib/versioned/printers/quiet.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const TestPrinter = require('./printer')
+
+/**
+ * A printer that will only write output to the destination stream when
+ * an error has occurred in a test suite.
+ */
+class QuietPrinter extends TestPrinter {
+  constructor(tests, options) {
+    super(tests, options)
+  }
+
+  print() {
+    // This method is required by TestPrinter.maybePrint, but we don't need
+    // to do anything.
+  }
+
+  update(test, status) {
+    // This method is used by the runner to update the status of a test.
+    // We only care if the test has failed. If it has, then indicate that
+    // the output should be printed.
+    const failed = this._isFailure(status) === true
+    this._doUpdate(test, status, failed === true)
+  }
+}
+
+module.exports = QuietPrinter


### PR DESCRIPTION
This is in service to https://github.com/newrelic/node-newrelic/issues/2122.

I have tested this locally by `npm link`ing this into my local `newrelic` repo, modifying tests to fail, and running the versioned tests. When there are test failures, output is printed to screen. When tests are successful, nothing is printed.