### PR TITLE
refactor: Removed --all flag from versioned runner as all runs will be using this since we no longer support Node.js versions that do not ship with npm7

### DIFF
--- a/bin/version-manager.js
+++ b/bin/version-manager.js
@@ -30,7 +30,6 @@ cmd
   .option('--major', 'Only iterate on major versions of packages.')
   .option('--minor', 'Iterate over minor versions of packages (default).')
   .option('--patch', 'Iterate over every patch version of packages.')
-  .option('-a, --all', 'Installs all packages, not just ones that differ in version')
   .option('--samples <n>', 'Global samples setting to override what is in tests package', int)
   .option('--strict', 'Throw an error if there are test files that are not being run')
   .action(async (testGlobs) => {
@@ -113,7 +112,6 @@ function run(files, patterns) {
     limit: maxParallelRuns,
     installLimit: cmd.install,
     versions: mode,
-    allPkgs: !!cmd.all,
     testPatterns: patterns,
     globalSamples: cmd.samples,
     strict: !!cmd.strict

--- a/lib/versioned/suite.js
+++ b/lib/versioned/suite.js
@@ -24,7 +24,6 @@ function Suite(testFolders, opts) {
       limit: 1,
       installLimit: 1,
       versions: 'minor',
-      allPkgs: false,
       testPatterns: [],
       globalSamples: null
     },

--- a/lib/versioned/test.js
+++ b/lib/versioned/test.js
@@ -41,7 +41,7 @@ function filterTestsByPattern(tests, testPatterns) {
 }
 
 function Test(directory, pkgVersions, opts = {}) {
-  const { allPkgs, testPatterns, globalSamples } = opts
+  const { testPatterns, globalSamples } = opts
   const pkg = require(path.join(directory, 'package'))
   const dirname = path.basename(directory)
 
@@ -78,7 +78,6 @@ function Test(directory, pkgVersions, opts = {}) {
   this.currentRun = null
   this.previousRun = null
   this.duration = 0
-  this.allPkgs = !!allPkgs
   this.strict = !!opts.strict
   this.type = pkg.type || 'commonjs'
 }
@@ -121,11 +120,6 @@ Test.prototype.run = function run() {
   // (e.g redis@1.2.1)
   task.packageVersions = Object.keys(task.packages).map((pkg) => `${pkg}@${task.packages[pkg]}`)
 
-  // previously this only installed package differences `pkgs` but with the introduction
-  // of npm 7, running `npm install <pkg>` would remove all packages not related to
-  // the one packages you were installing. The runner has a new -a prop that is a boolean
-  const pkgList = this.allPkgs ? task.packageVersions : pkgs
-
   const additionalArgs = {
     PKG_TYPE: this.type
   }
@@ -140,7 +134,7 @@ Test.prototype.run = function run() {
   }
 
   // Spawn another runner instance with list of packages to install
-  const child = cp.spawn('node', [TEST_EXECUTOR, task.test].concat(pkgList), {
+  const child = cp.spawn('node', [TEST_EXECUTOR, task.test].concat(task.packageVersions), {
     cwd: this.directory,
     stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
     env: { ...process.env, ...additionalArgs }

--- a/tests/unit/versioned/test.tap.js
+++ b/tests/unit/versioned/test.tap.js
@@ -215,12 +215,6 @@ tap.test('Test methods and members', function (t) {
         testRun.stdout,
         new RegExp(
           [
-            // pre-npm 7 shows the package + redis@1.0.0
-            '(?:\\+\\s+redis@1\\.0\\.0.*)?\n?',
-            // pre npm 7 if running tests on fresh checkout
-            '(?:\nadded \\d+ packages? from \\d contributor in \\d(?:\\.\\d+)?s)?\n?',
-            // pre npm 7 if running tests that already has tests/unit/versioned/mock-tests/node_modules
-            '(?:\nupdated \\d+ packages? in \\d(?:\\.\\d+)?s)?\n?',
             // npm 7 + if running tests on fresh checkout
             '(?:\nadded \\d+ packages? in \\d(?:\\.\\d+)?s)?\n?',
             // npm 7 + when running tests that already have tests/unit/versioned/mock-tests/node_modules
@@ -284,7 +278,18 @@ tap.test('Test methods and members', function (t) {
         )
 
         t.ok(nextRun.failed, 'should be marked as a failed run')
-        t.equal(nextRun.stdout, 'stdout - other.mock.tap.js\n', 'should have expected stdout')
+        t.match(
+          nextRun.stdout,
+          new RegExp(
+            [
+              // npm 7 + when running tests that already have tests/unit/versioned/mock-tests/node_modules
+              '(?:\nup to date in \\d(?:\\.\\d+)?s)?\n?',
+              // stdout from loading the fake module
+              '\nstdout - other\\.mock\\.tap\\.js\n'
+            ].join('')
+          ),
+          'should have expected stdout'
+        )
 
         /* eslint-disable max-len */
         t.match(
@@ -301,87 +306,6 @@ tap.test('Test methods and members', function (t) {
       })
     }
   })
-})
-
-tap.test('Test run with allPkgs true', function (t) {
-  const test = new Test(MOCK_TEST_DIR, pkgVersions, { allPkgs: true })
-
-  const testRun = test.run()
-  testRun.on('end', function () {
-    t.match(
-      testRun.stdout,
-      new RegExp(
-        [
-          // pre-npm 7 shows the package + redis@1.0.0
-          '(?:\\+\\s+redis@1\\.0\\.0.*)?\n?',
-          // pre npm 7 if running tests on fresh checkout
-          '(?:\nadded \\d+ packages? from \\d contributor in \\d(?:\\.\\d+)?s)?\n?',
-          // pre npm 7 if running tests that already has tests/unit/versioned/mock-tests/node_modules
-          '(?:\nupdated \\d+ packages? in \\d(?:\\.\\d+)?s)?\n?',
-          // npm 7 + if running tests on fresh checkout
-          '(?:\nadded \\d+ packages? in \\d(?:\\.\\d+)?s)?\n?',
-          // npm 7 + when running tests that already have tests/unit/versioned/mock-tests/node_modules
-          '(?:\nup to date in \\d(?:\\.\\d+)?s)?\n?',
-          // stdout from loading the fake module
-          '\nstdout - redis\\.mock\\.tap\\.js\n'
-        ].join('')
-      ),
-      'should have expected stdout from redis.mock.tap.js'
-    )
-    t.equal(
-      testRun.stderr,
-      'stderr - redis.mock.tap.js\n',
-      'should have expected stderr from redis.mock.tap.js'
-    )
-
-    const nextRun = test.run()
-
-    nextRun.on('end', function () {
-      t.match(
-        nextRun.stdout,
-        new RegExp(
-          [
-            // pre-npm 7 shows the package + redis@1.0.0
-            '(?:\\+\\s+redis@1\\.0\\.0.*)?\n?',
-            // pre npm 7 if running tests on fresh checkout
-            '(?:\nadded \\d+ packages? from \\d contributor in \\d(?:\\.\\d+)?s)?\n?',
-            // pre npm 7 if running tests that already has tests/unit/versioned/mock-tests/node_modules
-            '(?:\nupdated \\d+ packages? in \\d(?:\\.\\d+)?s)?\n?',
-            // npm 7 + if running tests on fresh checkout
-            '(?:\nadded \\d+ packages? in \\d(?:\\.\\d+)?s)?\n?',
-            // npm 7 + when running tests that already have tests/unit/versioned/mock-tests/node_modules
-            '(?:\nup to date in \\d(?:\\.\\d+)?s)?\n?',
-            // stdout from loading the fake module
-            '\nstdout - other\\.mock\\.tap\\.js\n'
-          ].join('')
-        ),
-        'should have expected stdout from other.mock.tap.js'
-      )
-      t.match(
-        nextRun.stderr,
-        new RegExp(
-          [
-            'stderr - other\\.mock\\.tap\\.js',
-            'Failed to execute test: Error: Failed to execute node'
-          ].join('\n')
-        ),
-        'should have expected stderr from other.mock.tap.js'
-      )
-
-      t.end()
-    })
-
-    nextRun.on('completed', function () {
-      nextRun.continue()
-    })
-    nextRun.continue()
-  })
-  testRun.on('completed', function () {
-    testRun.continue()
-  })
-  testRun.continue()
-  test.peek()
-  testRun.continue()
 })
 
 tap.test('Will not filter tests when keywords are an empty list', function (t) {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

Saw this on the issue queue and we can address since we dropped support for node 16.  Once this is done we can update our versioned test calls in repos to no longer pass the `--all` flag.

### How to test
```sh
npm link
cd <checkout-of-node-agent>
npm link @newrelic/test-utilitites
# Should still work without passing the --all flag
./node_modules/.bin/versioned-tests --minor --print pretty -i 2 --strict --samples 10 test/versioned/kafkajs
````

## Related Issues
Closes #80
