### PR TITLE
ci: Fixed test script to run all unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint:lockfile": "lockfile-lint --path package-lock.json --type npm --allowed-hosts npm --validate-https --validate-integrity",
     "test": "npm run unit",
     "third-party-updates": "oss third-party manifest && oss third-party notices && git add THIRD_PARTY_NOTICES.md third_party_manifest.json",
-    "unit": "c8 -o ./coverage/unit tap tests/unit/*.tap.js tests/unit/*/*.tap.js --no-coverage --reporter classic",
+    "unit": "c8 -o ./coverage/unit tap --test-regex='(\\/|^tests\\/unit\\/.*\\.tap\\.js)$' --no-coverage --reporter classic",
     "prepare": "husky install"
   },
   "bin": {

--- a/tests/unit/versioned/globber.tap.js
+++ b/tests/unit/versioned/globber.tap.js
@@ -46,9 +46,9 @@ tap.test('globber', (t) => {
     })
 
     t.test('specific file', (t) => {
-      const globs = globber.buildGlobs([`${TEST_DIR}/other.mock.tap.js`])
+      const globs = globber.buildGlobs([`${TEST_DIR}/other.mock.test.js`])
       t.equal(globs.length, 1)
-      t.match(globs, [`${TEST_DIR}/other.mock.tap.js`])
+      t.match(globs, [`${TEST_DIR}/other.mock.test.js`])
       t.end()
     })
   })
@@ -59,7 +59,7 @@ tap.test('globber', (t) => {
     t.test('resolve asterisk', async (t) => {
       const files = await globber.resolveGlobs([`${TEST_DIR}/*.js`])
       t.equal(files.length, 2)
-      t.match(files, [`${TEST_DIR}/other.mock.tap.js`, `${TEST_DIR}/redis.mock.tap.js`])
+      t.match(files, [`${TEST_DIR}/other.mock.test.js`, `${TEST_DIR}/redis.mock.test.js`])
       t.end()
     })
 
@@ -76,17 +76,17 @@ tap.test('globber', (t) => {
     t.test('handle skips', async (t) => {
       const files = await globber.resolveGlobs(
         [`${TEST_DIR}/*.js`],
-        [`${TEST_DIR}/redis.mock.tap.js`]
+        [`${TEST_DIR}/redis.mock.test.js`]
       )
       t.equal(files.length, 1)
-      t.match(files, [`${TEST_DIR}/other.mock.tap.js`])
+      t.match(files, [`${TEST_DIR}/other.mock.test.js`])
       t.end()
     })
 
     t.test('handle duplicates', async (t) => {
       const files = await globber.resolveGlobs([`${TEST_DIR}/*.js`, `${TEST_DIR}/*.js`])
       t.equal(files.length, 2)
-      t.match(files, [`${TEST_DIR}/other.mock.tap.js`, `${TEST_DIR}/redis.mock.tap.js`])
+      t.match(files, [`${TEST_DIR}/other.mock.test.js`, `${TEST_DIR}/redis.mock.test.js`])
       t.end()
     })
   })

--- a/tests/unit/versioned/mock-esm-tests/package.json
+++ b/tests/unit/versioned/mock-esm-tests/package.json
@@ -5,6 +5,6 @@
   "private": true,
   "tests": [{
     "dependencies": {"redis": ">=1.0.0"},
-    "files": ["redis.mock.tap.js"]
+    "files": ["redis.mock.test.js"]
   }]
 }

--- a/tests/unit/versioned/mock-esm-tests/redis.mock.test.js
+++ b/tests/unit/versioned/mock-esm-tests/redis.mock.test.js
@@ -5,7 +5,7 @@
 
 'use strict'
 
-console.log('stdout - redis.mock.tap.js')
-console.error('stderr - redis.mock.tap.js')
+console.log('stdout - redis.mock.test.js')
+console.error('stderr - redis.mock.test.js')
 /* eslint-disable no-process-exit */
 process.exit(0)

--- a/tests/unit/versioned/mock-tests/other.mock.test.js
+++ b/tests/unit/versioned/mock-tests/other.mock.test.js
@@ -5,7 +5,7 @@
 
 'use strict'
 
-console.log('stdout - redis.mock.tap.js')
-console.error('stderr - redis.mock.tap.js')
+console.log('stdout - other.mock.test.js')
+console.error('stderr - other.mock.test.js')
 /* eslint-disable no-process-exit */
-process.exit(0)
+process.exit(1)

--- a/tests/unit/versioned/mock-tests/package.json
+++ b/tests/unit/versioned/mock-tests/package.json
@@ -5,9 +5,9 @@
   "tests": [{
     "engines": {"node": "<0.1.0"},
     "dependencies": {"redis": "*"},
-    "files": ["redis.mock.tap.js", "other.mock.tap.js"]
+    "files": ["redis.mock.test.js", "other.mock.test.js"]
   }, {
     "dependencies": {"redis": ">=1.0.0"},
-    "files": ["redis.mock.tap.js", "other.mock.tap.js"]
+    "files": ["redis.mock.test.js", "other.mock.test.js"]
   }]
 }

--- a/tests/unit/versioned/mock-tests/redis.mock.test.js
+++ b/tests/unit/versioned/mock-tests/redis.mock.test.js
@@ -5,7 +5,7 @@
 
 'use strict'
 
-console.log('stdout - other.mock.tap.js')
-console.error('stderr - other.mock.tap.js')
+console.log('stdout - redis.mock.test.js')
+console.error('stderr - redis.mock.test.js')
 /* eslint-disable no-process-exit */
-process.exit(1)
+process.exit(0)

--- a/tests/unit/versioned/printers/printer.tap.js
+++ b/tests/unit/versioned/printers/printer.tap.js
@@ -53,12 +53,12 @@ tap.test('maybePrintMissing', function (t) {
     printer.tests.bluebird.test = { missingFiles: ['file1', 'file2', 'file3'] }
     printer.tests.redis.test = { missingFiles: ['file3', 'file4', 'file5'] }
     printer.maybePrintMissing()
-    t.same(console.log.args, [
+    t.match(console.log.args, [
       [
-        `\u001b[31mThe following test suites had test files that were not included in their package.json:\n\u001b[39m`
+        `The following test suites had test files that were not included in their package.json:\n`
       ],
-      [`\u001b[31mbluebird:\n\t- file1\n\t- file2\n\t- file3\u001b[39m`],
-      [`\u001b[31mredis:\n\t- file3\n\t- file4\n\t- file5\u001b[39m`]
+      [`bluebird:\n\t- file1\n\t- file2\n\t- file3`],
+      [`redis:\n\t- file3\n\t- file4\n\t- file5`]
     ])
     t.end()
   })
@@ -109,7 +109,7 @@ tap.test('printVersionedMatrix', function (t) {
         }
       ],
       {
-        bluebird: ['1.0.3', '1.3.4', '2.0.1', '3.8.1', '4.0.0']
+        bluebird: { versions: ['1.0.3', '1.3.4', '2.0.1', '3.8.1', '4.0.0'] }
       }
     )
     const redisMatrix = new TestMatrix(
@@ -125,7 +125,7 @@ tap.test('printVersionedMatrix', function (t) {
         }
       ],
       {
-        redis: ['1.2.3', '1.3.4', '2.0.1']
+        redis: { versions: ['1.2.3', '1.3.4', '2.0.1'] }
       }
     )
     printer.tests.bluebird.test = { matrix: bluebirdMatrix }
@@ -152,7 +152,7 @@ tap.test('printVersionedMatrix', function (t) {
         }
       ],
       {
-        bluebird: ['2.0.0']
+        bluebird: { versions: ['2.0.0'] }
       }
     )
     const redisMatrix = new TestMatrix(
@@ -168,7 +168,7 @@ tap.test('printVersionedMatrix', function (t) {
         }
       ],
       {
-        redis: ['1.2.3', '1.3.4', '2.0.1']
+        redis: { versions: ['1.2.3', '1.3.4', '2.0.1'] }
       }
     )
     printer.tests.bluebird.test = { matrix: bluebirdMatrix }

--- a/tests/unit/versioned/suite.tap.js
+++ b/tests/unit/versioned/suite.tap.js
@@ -32,12 +32,12 @@ tap.test('Suite method and members', function (t) {
 
   t.test('Suite#start', function (t) {
     const updates = [
-      { test: 'redis.mock.tap.js', status: 'waiting' },
-      { test: 'redis.mock.tap.js', status: 'installing' },
-      { test: 'redis.mock.tap.js', status: 'running' },
-      { test: 'redis.mock.tap.js', status: 'success' },
-      { test: 'other.mock.tap.js', status: 'running' },
-      { test: 'other.mock.tap.js', status: 'failure' }
+      { test: 'redis.mock.test.js', status: 'waiting' },
+      { test: 'redis.mock.test.js', status: 'installing' },
+      { test: 'redis.mock.test.js', status: 'running' },
+      { test: 'redis.mock.test.js', status: 'success' },
+      { test: 'other.mock.test.js', status: 'running' },
+      { test: 'other.mock.test.js', status: 'failure' }
       // No "done" event because last test failed.
     ]
     let updateIdx = 0

--- a/tests/unit/versioned/test.tap.js
+++ b/tests/unit/versioned/test.tap.js
@@ -107,7 +107,7 @@ tap.test('Test methods and members', function (t) {
       peek,
       {
         packages: { redis: '1.0.0' },
-        test: MOCK_TEST_DIR + '/redis.mock.tap.js'
+        test: MOCK_TEST_DIR + '/redis.mock.test.js'
       },
       'should return the next test to execute'
     )
@@ -124,7 +124,7 @@ tap.test('Test methods and members', function (t) {
       next,
       {
         packages: { redis: '1.0.0' },
-        test: MOCK_TEST_DIR + '/redis.mock.tap.js'
+        test: MOCK_TEST_DIR + '/redis.mock.test.js'
       },
       'should return the next test to execute'
     )
@@ -134,7 +134,7 @@ tap.test('Test methods and members', function (t) {
       next,
       {
         packages: { redis: '1.0.0' },
-        test: MOCK_TEST_DIR + '/other.mock.tap.js'
+        test: MOCK_TEST_DIR + '/other.mock.test.js'
       },
       'should advance the state of the test'
     )
@@ -144,7 +144,7 @@ tap.test('Test methods and members', function (t) {
       next,
       {
         packages: { redis: '2.0.1' },
-        test: MOCK_TEST_DIR + '/redis.mock.tap.js'
+        test: MOCK_TEST_DIR + '/redis.mock.test.js'
       },
       'should advance the package versions when out of test files'
     )
@@ -220,13 +220,13 @@ tap.test('Test methods and members', function (t) {
             // npm 7 + when running tests that already have tests/unit/versioned/mock-tests/node_modules
             '(?:\nup to date in \\d(?:\\.\\d+)?s)?\n?',
             // stdout from loading the fake module
-            '\nstdout - redis\\.mock\\.tap\\.js\n'
+            '\nstdout - redis\\.mock\\.test\\.js\n'
           ].join('')
         ),
         'should have expected stdout'
       )
 
-      t.equal(testRun.stderr, 'stderr - redis.mock.tap.js\n', 'should have expected stderr')
+      t.equal(testRun.stderr, 'stderr - redis.mock.test.js\n', 'should have expected stderr')
 
       nextTest()
     })
@@ -285,7 +285,7 @@ tap.test('Test methods and members', function (t) {
               // npm 7 + when running tests that already have tests/unit/versioned/mock-tests/node_modules
               '(?:\nup to date in \\d(?:\\.\\d+)?s)?\n?',
               // stdout from loading the fake module
-              '\nstdout - other\\.mock\\.tap\\.js\n'
+              '\nstdout - other\\.mock\\.test\\.js\n'
             ].join('')
           ),
           'should have expected stdout'
@@ -296,7 +296,7 @@ tap.test('Test methods and members', function (t) {
           nextRun.stderr,
           new RegExp(
             [
-              'stderr - other\\.mock\\.tap\\.js',
+              'stderr - other\\.mock\\.test\\.js',
               'Failed to execute test: Error: Failed to execute node'
             ].join('\n')
           ),
@@ -319,7 +319,7 @@ tap.test('Will not filter tests when keywords are an empty list', function (t) {
 
 tap.test('should filter based on multiple keywords', function (t) {
   const test = new Test(MOCK_TEST_DIR, pkgVersions, {
-    testPatterns: ['other.mock.tap.js', 'redis']
+    testPatterns: ['other.mock.test.js', 'redis']
   })
 
   t.equal(test.matrix._matrix[1].tests.files.length, 2, 'should include both test files')
@@ -334,7 +334,7 @@ tap.test('Can filter tests by keyword', function (t) {
   t.equal(test.matrix._matrix[1].tests.files.length, 1, 'should include only one test file')
   t.equal(
     test.matrix._matrix[1].tests.files[0],
-    'redis.mock.tap.js',
+    'redis.mock.test.js',
     'should only include the redis test file'
   )
   t.end()
@@ -351,7 +351,7 @@ tap.test('should filter tests completely out when 0 matches based on patterns', 
 
 tap.test('check for unspecified test files', function (t) {
   t.autoend()
-  const testFile = path.join(MOCK_TEST_DIR, 'ignoreme.mock.tap.js')
+  const testFile = path.join(MOCK_TEST_DIR, 'ignoreme.mock.test.js')
 
   t.beforeEach(() => {
     fs.writeFileSync(testFile, 'hello world')


### PR DESCRIPTION
 fixed printers test as it was not being run,

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

Amy noticed this when she was working on her refactor.  This PR fixes the regex for tap to make sure all unit tests were being run. I had to rename to fake tests from `.tap.js` to `test.js` so they wouldn't get run.

