### PR TITLE
refactor: Reduced dependency on async library

### DIFF
--- a/lib/versioned/packager.js
+++ b/lib/versioned/packager.js
@@ -18,34 +18,36 @@ Packager.prototype.get = function get(name, wantedVersion) {
   })
 }
 
-Packager.prototype.load = function load(name, cb) {
-  const self = this
-  https.get(
-    {
-      host: 'registry.npmjs.org',
-      path: '/' + name.replace('/', encodeURIComponent),
-      headers: { accept: 'application/json' }
-    },
-    function handleRes(response) {
-      // Accumulate the response.
-      let body = ''
-      response.on('data', (data) => {
-        body += data.toString('utf8')
-      })
-      response.on('end', () => {
-        // Attempt to parse the reponse.
-        let info = null
-        try {
-          info = JSON.parse(body)
-        } catch (e) {
-          return cb(e)
-        }
+Packager.prototype.load = function load(name) {
+  return new Promise((resolve, reject) => {
+    const self = this
+    https.get(
+      {
+        host: 'registry.npmjs.org',
+        path: '/' + name.replace('/', encodeURIComponent),
+        headers: { accept: 'application/json' }
+      },
+      function handleRes(response) {
+        // Accumulate the response.
+        let body = ''
+        response.on('data', (data) => {
+          body += data.toString('utf8')
+        })
+        response.on('end', () => {
+          // Attempt to parse the reponse.
+          let info = null
+          try {
+            info = JSON.parse(body)
+          } catch (e) {
+            return reject(e)
+          }
 
-        self._cache[name] = Object.keys(info.versions)
-        cb(null, info.versions)
-      })
-    }
-  )
+          self._cache[name] = Object.keys(info.versions)
+          resolve(info.versions)
+        })
+      }
+    )
+  })
 }
 
 module.exports = new Packager()

--- a/lib/versioned/runner.js
+++ b/lib/versioned/runner.js
@@ -30,138 +30,129 @@ if (!packages.length) {
 }
 const testFile = packages.shift()
 
-a.series(
-  [
-    // 1) Install all our packages.
-    makeWaiter(installPackages),
-
-    // 2) Run the test!
-    makeWaiter(runTests)
-  ],
-  function endHandler(err) {
-    const status = { status: 'done', error: null }
-    if (err) {
-      console.error(err.message)
-      status.error = {
-        message: err.message,
-        code: err.code
-      }
-    }
+async function main() {
+  let error
+  try {
+    await installPackages()
+    await runTests()
+  } catch(err) {
+    error = err
+    console.error(err.message)
+  } finally {
+    const status = { status: 'done', error }
     process.send(status)
     // eslint-disable-next-line no-process-exit
-    process.exit((err && err.code) || 0)
-  }
-)
-
-function makeWaiter(action) {
-  return function waiterHandler(cb) {
-    process.once('message', function msgHandler(msg) {
-      if (msg.command === 'continue') {
-        action((err) => {
-          process.send({ status: 'completed' })
-          cb(err)
-        })
-      } else {
-        const err = new Error('Received wrong command.')
-        err.code = -1
-        cb(err)
-      }
-    })
+    process.exit(error?.code || 0)
   }
 }
 
-function installPackages(cb) {
-  process.send({ status: 'installing' })
-  if (packages.length === 0) {
-    return cb()
-  }
+async function installPackages() {
+  return new Promise((resolve, reject) => {
+    process.once('message', async function handler() {
+      process.send({ status: 'installing' })
+      if (packages.length === 0) {
+        resolve()
+      }
 
-  tryInstall()
-
-  function tryInstall() {
-    let args = [
-      'install',
-      '--no-save', // do not update package file
-      '--no-package-lock', // do not update package-lock file
-      '--no-audit', // skip audit output
-      '--no-fund' // skip funding output
-    ]
-    args = args.concat(packages)
-    spawn('npm', args, function installHandler(err) {
-      if (err) {
+      let args = [
+        'install',
+        '--no-save', // do not update package file
+        '--no-package-lock', // do not update package-lock file
+        '--no-audit', // skip audit output
+        '--no-fund' // skip funding output
+      ]
+      args = args.concat(packages)
+      try {
+        await spawn('npm', args)
+        resolve()
+      } catch(err) {
         err.code = -Math.abs(err.code)
+        reject(err)
+      } finally {
+        process.send({ status: 'completed' })
       }
-      cb(err)
     })
-  }
-}
-
-function runTests(cb) {
-  // TODO: Add tap arguments, such as color.
-  process.send({ status: 'running' })
-  let args = [testFile]
-  if (process.env.PKG_TYPE === 'module' && process.env.NR_LOADER) {
-    const loaderPath = path.resolve(process.env.NR_LOADER)
-    const loaderArg = semver.lt(process.version, '18.0.0') ? '--experimental-loader' : '--loader'
-    args = [loaderArg, loaderPath, testFile]
-  }
-
-  spawn('node', args, function testHandler(err) {
-    if (err) {
-      const error = new Error('Failed to execute test: ' + err.stack)
-      error.code = Math.abs(err.code)
-      return cb(error)
-    }
-    cb()
   })
 }
 
-function spawn(cmd, args, cb) {
-  const child = cp.spawn(cmd, args, {
-    stdio: ['ignore', process.stdout, process.stderr, 'ipc']
-  })
-
-  let terminated = false
-  let timeout = setTimeout(function sigTerm() {
-    child.kill('SIGTERM')
-    terminated = true
-    timeout = setTimeout(function sigKill() {
-      child.kill('SIGKILL')
-    }, CHILD_KILL_TIMEOUT)
-  }, CHILD_TIMEOUT)
-
-  let error = null
-  child.on('error', function erroHandler(err) {
-    error = err
-  })
-
-  child.on('exit', function exitHandler(code, signal) {
-    clearTimeout(timeout)
-
-    if (code) {
-      if (!error) {
-        error = new Error('Failed to execute ' + cmd + ' ' + args.join(' '))
+async function runTests() {
+  return new Promise((resolve, reject) => {
+    process.once('message', async function handler() {
+      // TODO: Add tap arguments, such as color.
+      process.send({ status: 'running' })
+      let args = [testFile]
+      if (process.env.PKG_TYPE === 'module' && process.env.NR_LOADER) {
+        const loaderPath = path.resolve(process.env.NR_LOADER)
+        const loaderArg = semver.lt(process.version, '18.0.0') ? '--experimental-loader' : '--loader'
+        args = [loaderArg, loaderPath, testFile]
       }
-      error.code = code
-    } else if (!error && terminated) {
-      error = new Error('Command timed out: ' + cmd + ' ' + args.join(' '))
-      error.code = 0xbad
-    }
 
-    // https://nodejs.org/api/child_process.html#child_process_event_exit
-    // If the process exited, code is the final exit code of the process,
-    // otherwise null. If the process terminated due to receipt of a signal,
-    // signal is the string name of the signal, otherwise null. One of the
-    // two will always be non-null.
-    if (null === code && !error && signal) {
-      // if there's no exit code but we exited due to a received signal,
-      // raise an appropriate error.
-      error = new Error('Aborted with signal ' + signal + ' ' + cmd + ' ' + args.join(' '))
-      error.code = 0xbad
-    }
-
-    cb(error)
+      try {
+        await spawn('node', args)
+        resolve()
+      } catch(err) {
+        const error = new Error('Failed to execute test: ' + err.stack)
+        error.code = Math.abs(err.code)
+        reject(error)
+      } finally {
+        process.send({ status: 'completed' })
+      }
+    })
   })
-
-  return child
 }
+
+async function spawn(cmd, args) {
+  return new Promise((resolve, reject) => {
+    const child = cp.spawn(cmd, args, {
+      stdio: ['ignore', process.stdout, process.stderr, 'ipc']
+    })
+
+    let terminated = false
+    let timeout = setTimeout(function sigTerm() {
+      child.kill('SIGTERM')
+      terminated = true
+      timeout = setTimeout(function sigKill() {
+        child.kill('SIGKILL')
+      }, CHILD_KILL_TIMEOUT)
+    }, CHILD_TIMEOUT)
+
+    let error = null
+    child.on('error', function erroHandler(err) {
+      error = err
+    })
+
+    child.on('exit', function exitHandler(code, signal) {
+      clearTimeout(timeout)
+
+      if (code) {
+        if (!error) {
+          error = new Error('Failed to execute ' + cmd + ' ' + args.join(' '))
+        }
+        error.code = code
+      } else if (!error && terminated) {
+        error = new Error('Command timed out: ' + cmd + ' ' + args.join(' '))
+        error.code = 0xbad
+      }
+
+      // https://nodejs.org/api/child_process.html#child_process_event_exit
+      // If the process exited, code is the final exit code of the process,
+      // otherwise null. If the process terminated due to receipt of a signal,
+      // signal is the string name of the signal, otherwise null. One of the
+      // two will always be non-null.
+      if (null === code && !error && signal) {
+        // if there's no exit code but we exited due to a received signal,
+        // raise an appropriate error.
+        error = new Error('Aborted with signal ' + signal + ' ' + cmd + ' ' + args.join(' '))
+        error.code = 0xbad
+      }
+
+      if (error) {
+        reject(error)
+      } else {
+        resolve()
+      }
+    })
+  })
+}
+
+main()

--- a/lib/versioned/runner.js
+++ b/lib/versioned/runner.js
@@ -8,7 +8,6 @@
 /* eslint-disable no-console */
 
 const path = require('path')
-const a = require('async')
 const cp = require('child_process')
 const semver = require('semver')
 
@@ -35,7 +34,7 @@ async function main() {
   try {
     await installPackages()
     await runTests()
-  } catch(err) {
+  } catch (err) {
     error = err
     console.error(err.message)
   } finally {
@@ -65,7 +64,7 @@ async function installPackages() {
       try {
         await spawn('npm', args)
         resolve()
-      } catch(err) {
+      } catch (err) {
         err.code = -Math.abs(err.code)
         reject(err)
       } finally {
@@ -83,14 +82,16 @@ async function runTests() {
       let args = [testFile]
       if (process.env.PKG_TYPE === 'module' && process.env.NR_LOADER) {
         const loaderPath = path.resolve(process.env.NR_LOADER)
-        const loaderArg = semver.lt(process.version, '18.0.0') ? '--experimental-loader' : '--loader'
+        const loaderArg = semver.lt(process.version, '18.0.0')
+          ? '--experimental-loader'
+          : '--loader'
         args = [loaderArg, loaderPath, testFile]
       }
 
       try {
         await spawn('node', args)
         resolve()
-      } catch(err) {
+      } catch (err) {
         const error = new Error('Failed to execute test: ' + err.stack)
         error.code = Math.abs(err.code)
         reject(error)

--- a/lib/versioned/suite.js
+++ b/lib/versioned/suite.js
@@ -54,19 +54,11 @@ Suite.prototype.prepare = function prepare() {
   })
 }
 
-Suite.prototype.start = function start(cb) {
+Suite.prototype.start = async function start() { 
   this.prepare()
-  const self = this
-  a.waterfall(
-    [this._mapPackagesToVersions.bind(this), this._runTests.bind(this)],
-    function finishHandler(err) {
-      if (err && (!cb || self.listenerCount('error'))) {
-        self.emit('error', err)
-      }
-      self.emit('end')
-      cb && cb(err)
-    }
-  )
+  const pkgVersions = await this._mapPackagesToVersions()
+  await this._runTests(pkgVersions)
+  this.emit('end')
 }
 
 /**
@@ -97,43 +89,34 @@ Suite.prototype._buildPkgMeta = function _buildPkgMeta(name, versions) {
   }
 }
 
-Suite.prototype._mapPackagesToVersions = function _mapPackagesToVersions(cb) {
+Suite.prototype._mapPackagesToVersions = async function _mapPackagesToVersions() {
   const packages = Object.keys(this.pkgsMeta)
   const self = this
-  a.mapLimit(
+  const versions = await a.mapLimit(
     packages,
     this.opts.limit,
-    function loadPkgs(pkg, loadCb) {
+    async function loadPkgs(pkg) {
       // Request the package information from NPM's registry.
-      packager.load(pkg, function pkgLoad(err, versions) {
-        if (err) {
-          return loadCb(err)
-        }
-        const pkgMeta = self.pkgsMeta[pkg]
-        versions = testUtil.maxVersionPerMode(Object.keys(versions), self.opts.versions, pkgMeta)
-        self.emit('packageResolved', pkg, versions)
-        loadCb(null, { versions, latest: versions[versions.length - 1] })
-      })
-    },
-    function loadHandler(err, versions) {
-      if (err) {
-        return cb(new Error('Failed to retrieve package information: ' + err))
-      }
-
-      const pkgInfo = {}
-      for (let i = 0; i < packages.length; ++i) {
-        pkgInfo[packages[i]] = versions[i]
-      }
-
-      // Now we have all of the package versions we'll need in an object looking
-      // like this:
-      // {"package": { "versions": ["1.2", "1.3", "2.0"], "latest": "2.0"}}
-      cb(null, pkgInfo)
+      let versions = await packager.load(pkg)
+      const pkgMeta = self.pkgsMeta[pkg]
+      versions = testUtil.maxVersionPerMode(Object.keys(versions), self.opts.versions, pkgMeta)
+      self.emit('packageResolved', pkg, versions)
+      return { versions, latest: versions[versions.length - 1] }
     }
   )
+
+  const pkgInfo = {}
+  for (let i = 0; i < packages.length; ++i) {
+    pkgInfo[packages[i]] = versions[i]
+  }
+
+  // Now we have all of the package versions we'll need in an object looking
+  // like this:
+  // {"package": { "versions": ["1.2", "1.3", "2.0"], "latest": "2.0"}}
+  return pkgInfo
 }
 
-Suite.prototype._runTests = function _runTests(pkgVersions, cb) {
+Suite.prototype._runTests = async function _runTests(pkgVersions) {
   this.failures = []
   const self = this
 
@@ -194,7 +177,7 @@ Suite.prototype._runTests = function _runTests(pkgVersions, cb) {
     queue.push(test)
   })
 
-  queue.drain(cb)
+  await queue.drain()
 }
 
 module.exports = Suite

--- a/lib/versioned/suite.js
+++ b/lib/versioned/suite.js
@@ -54,7 +54,7 @@ Suite.prototype.prepare = function prepare() {
   })
 }
 
-Suite.prototype.start = async function start() { 
+Suite.prototype.start = async function start() {
   this.prepare()
   const pkgVersions = await this._mapPackagesToVersions()
   await this._runTests(pkgVersions)
@@ -92,27 +92,22 @@ Suite.prototype._buildPkgMeta = function _buildPkgMeta(name, versions) {
 Suite.prototype._mapPackagesToVersions = async function _mapPackagesToVersions() {
   const packages = Object.keys(this.pkgsMeta)
   const self = this
-  const versions = await a.mapLimit(
-    packages,
-    this.opts.limit,
-    async function loadPkgs(pkg) {
-      // Request the package information from NPM's registry.
-      let versions = await packager.load(pkg)
-      const pkgMeta = self.pkgsMeta[pkg]
-      versions = testUtil.maxVersionPerMode(Object.keys(versions), self.opts.versions, pkgMeta)
-      self.emit('packageResolved', pkg, versions)
-      return { versions, latest: versions[versions.length - 1] }
-    }
-  )
+  const versionsFinal = await a.mapLimit(packages, this.opts.limit, async function loadPkgs(pkg) {
+    // Request the package information from NPM's registry.
+    let versions = await packager.load(pkg)
+    const pkgMeta = self.pkgsMeta[pkg]
+    versions = testUtil.maxVersionPerMode(Object.keys(versions), self.opts.versions, pkgMeta)
+    self.emit('packageResolved', pkg, versions)
+    return { versions, latest: versions[versions.length - 1] }
+  })
 
   const pkgInfo = {}
   for (let i = 0; i < packages.length; ++i) {
-    pkgInfo[packages[i]] = versions[i]
+    pkgInfo[packages[i]] = versionsFinal[i]
   }
 
   // Now we have all of the package versions we'll need in an object looking
-  // like this:
-  // {"package": { "versions": ["1.2", "1.3", "2.0"], "latest": "2.0"}}
+  // like this: {"package": { "versions": ["1.2", "1.3", "2.0"], "latest": "2.0"}}
   return pkgInfo
 }
 

--- a/tests/unit/versioned/suite.tap.js
+++ b/tests/unit/versioned/suite.tap.js
@@ -30,7 +30,7 @@ tap.test('Suite method and members', function (t) {
     suite = new Suite([MOCK_TEST_DIR])
   })
 
-  t.test('Suite#start', function (t) {
+  t.test('Suite#start', async function (t) {
     const updates = [
       { test: 'redis.mock.test.js', status: 'waiting' },
       { test: 'redis.mock.test.js', status: 'installing' },
@@ -43,7 +43,7 @@ tap.test('Suite method and members', function (t) {
     let updateIdx = 0
     const UPDATE_TEST_COUNT = 2
 
-    t.plan(UPDATE_TEST_COUNT * updates.length + 3)
+    t.plan(UPDATE_TEST_COUNT * updates.length + 1)
 
     suite.on('update', function (test, status) {
       const expected = updates[updateIdx++]
@@ -57,9 +57,6 @@ tap.test('Suite method and members', function (t) {
       t.pass('should emit end event')
     })
 
-    suite.start(function (err) {
-      t.pass('should call back')
-      t.error(err, 'should not error')
-    })
+    await suite.start()
   })
 })


### PR DESCRIPTION
- Got rid of async functions in runner
- Got rid of async.waterfall in Suite.start()
- Reduced complexity of async.queue and async.mapLimit in Suite._runTests() and Suite._mapPackagesToVersions(), respectively
- Removed unnecessary callbacks and a test that checks for a callback