### PR TITLE
refactor: Removed install queue from versioned runner. It will install before running a given test and rely on the jobs limit

### DIFF
--- a/bin/version-manager.js
+++ b/bin/version-manager.js
@@ -20,7 +20,6 @@ const { buildGlobs, resolveGlobs } = require('../lib/versioned/globber')
 cmd
   .arguments('[test-globs...]')
   .option('-j, --jobs <n>', 'Max parallel test executions. Defaults to max available CPUs.', int)
-  .option('-i, --install <n>', 'Max parallel installations [1]', int, 1)
   .option('-p, --print <mode>', 'Specify print mode [pretty]', printMode, 'pretty')
   .option('-s, --skip <keyword>[,<keyword>]', 'Skip files containing the supplied keyword(s)')
   .option(
@@ -110,7 +109,6 @@ async function run(files, patterns) {
 
   const runner = new Suite(directories, {
     limit: maxParallelRuns,
-    installLimit: cmd.install,
     versions: mode,
     testPatterns: patterns,
     globalSamples: cmd.samples,

--- a/lib/versioned/suite.js
+++ b/lib/versioned/suite.js
@@ -22,7 +22,6 @@ function Suite(testFolders, opts) {
     {},
     {
       limit: 1,
-      installLimit: 1,
       versions: 'minor',
       testPatterns: [],
       globalSamples: null
@@ -115,12 +114,6 @@ Suite.prototype._runTests = async function _runTests(pkgVersions) {
   this.failures = []
   const self = this
 
-  const installQueue = a.queue(function install(test, installCb) {
-    self.emit('update', test.test, 'installing')
-    test.testRun.continue()
-    test.testRun.once('completed', installCb)
-  }, this.opts.installLimit)
-
   const queue = a.queue(function done(test, queueCb) {
     const testRun = test.run()
     if (!testRun) {
@@ -148,19 +141,13 @@ Suite.prototype._runTests = async function _runTests(pkgVersions) {
     })
 
     if (testRun.needsInstall) {
-      self.emit('update', test, 'waiting')
-      installQueue.push({ test: test, testRun: testRun }, doRun)
-    } else {
-      // Even if nothing is being installed the runner must go through the
-      // install phase.
-      testRun.continue()
-      testRun.once('completed', doRun)
+      self.emit('update', test, 'installing')
     }
-
-    function doRun() {
+    testRun.continue()
+    testRun.once('completed', () => {
       self.emit('update', test, 'running')
       testRun.continue()
-    }
+    })
   }, this.opts.limit)
 
   // Build and queue all of our test directories. The tests are sorted by number

--- a/tests/unit/versioned/suite.tap.js
+++ b/tests/unit/versioned/suite.tap.js
@@ -32,7 +32,6 @@ tap.test('Suite method and members', function (t) {
 
   t.test('Suite#start', async function (t) {
     const updates = [
-      { test: 'redis.mock.test.js', status: 'waiting' },
       { test: 'redis.mock.test.js', status: 'installing' },
       { test: 'redis.mock.test.js', status: 'running' },
       { test: 'redis.mock.test.js', status: 'success' },


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

Removes the install queue as it was adding unneccessary complexity.  Now the code will install packages if it needs to and then execute a given test suite when install is done. Before it did the same but queued up installs separately so it was doing a lot of waiting.

## How to Test

```
npm test
```

To test with agent

```
npm link
# In agent run
npm link @newrelic/test-utilities
npm run versioned:internal:major
```

## Related Issues
Closes #220
