### PR TITLE
feat: Added a --matrix-count parameter to versioned tests

### DIFF
--- a/lib/versioned/suite.js
+++ b/lib/versioned/suite.js
@@ -24,7 +24,8 @@ function Suite(testFolders, opts) {
       limit: 1,
       versions: 'minor',
       testPatterns: [],
-      globalSamples: null
+      globalSamples: null,
+      matrixCountOnly: false
     },
     opts
   )
@@ -56,6 +57,13 @@ Suite.prototype.prepare = function prepare() {
 Suite.prototype.start = async function start() {
   this.prepare()
   const pkgVersions = await this._mapPackagesToVersions()
+
+  if (this.opts.matrixCountOnly === true) {
+    this.emit('matrixCountReady')
+    this.emit('end')
+    return
+  }
+
   await this._runTests(pkgVersions)
   this.emit('end')
 }


### PR DESCRIPTION
This PR adds a new option to the versioned tests runner that enables calculating the number of tests that will be run and printing only that information.

<details>
<summary>Example output</summary>

```sh
# ... snipped
@prisma/client(19)
prisma(104)


Module Test Versions Counts
@apollo/gateway                        6
@apollo/server                         12
@apollo/subgraph                       15
@aws-sdk/client-api-gateway            322
@aws-sdk/client-bedrock-runtime        68
@aws-sdk/client-dynamodb               337
@aws-sdk/client-elastic-load-balancing 318
@aws-sdk/client-elasticache            325
@aws-sdk/client-lambda                 337
@aws-sdk/client-rds                    364
@aws-sdk/client-redshift               326
@aws-sdk/client-rekognition            325
@aws-sdk/client-s3                     356
@aws-sdk/client-ses                    321
@aws-sdk/client-sns                    322
@aws-sdk/client-sqs                    322
@aws-sdk/lib-dynamodb                  125
@aws-sdk/util-dynamodb                 342
@elastic/elasticsearch                 18
@elastic/transport                     8
@grpc/grpc-js                          8
@hapi/hapi                             7
@hapi/vision                           4
@koa/router                            11
@langchain/community                   3
@langchain/core                        2
@langchain/openai                      3
@nestjs/cli                            14
@prisma/client                         19
amazon-dax-client                      1
amqplib                                6
apollo-server                          14
apollo-server-express                  14
async-listener                         7
aws-sdk                                1,216
axios                                  36
bluebird                               20
body-parser                            21
bunyan                                 2
cassandra-driver                       11
connect                                39
continuation-local-storage             3
director                               1
ejs                                    21
express                                16
express-enrouten                       8
fastify                                75
flush-write-stream                     3
generic-pool                           0
graphql                                42
graphql-tag                            18
ioredis                                37
kafkajs                                3
koa                                    16
koa-route                              4
koa-router                             12
memcached                              1
middie                                 21
mongodb                                46
mysql                                  17
mysql2                                 16
next                                   9
openai                                 57
parse-json                             14
pg                                     11
pg-native                              4
pino                                   37
prisma                                 104
q                                      3
react                                  42
react-dom                              30
redis                                  19
restify                                27
restify-errors                         13
split2                                 13
superagent                             27
swagger-ui-express                     12
undici                                 59
when                                   1
winston                                15
winston-transport                      8
----------------------------------------
total:                                 6,892

real	0m8.135s
user	0m4.113s
sys	0m1.883s
```

</details>